### PR TITLE
feat(skill): add skill plugin for functional domain modeling principles

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "functional-ts-principal",
+  "description": "Principles for functional domain modeling in server-side TypeScript: discriminated unions, pure state transitions, Result types, and boundary defense",
+  "version": "0.1.0",
+  "author": {
+    "name": "Kosui Iwasa"
+  },
+  "repository": "https://github.com/iwasa-kosui/functional-ts-principal",
+  "license": "MIT",
+  "keywords": [
+    "typescript",
+    "functional-programming",
+    "domain-modeling",
+    "discriminated-union",
+    "coding-agent"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
 # functional-ts-principal
+
+サーバーサイドTypeScriptで関数型ドメインモデリングを実践するための原則を、コーディングエージェント向けスキルプラグインとして提供する。
+
+## 原則の概要
+
+- **Discriminated Union** でドメインの状態を表現し、classを避ける
+- **純粋関数** で状態遷移を定義し、無効な遷移をコンパイルエラーにする
+- **Result型** (neverthrow) でエラーを値として扱い、例外のthrowを避ける
+- **Zod** で外部境界をバリデーションし、ドメイン内部では型を信頼する
+- **Sensitive型** でPIIをランタイムレベルで保護する
+
+## インストール
+
+```bash
+npx skills add iwasa-kosui/functional-ts-principal
+```
+
+## 提供スキル
+
+### `functional-ts`
+
+TypeScriptのサーバーサイドコード（ドメインモデル、ユースケース、リポジトリ）を書くときに自動トリガーされる。原則に沿ったコード生成をガイドする。
+
+### `functional-ts-review`
+
+コードレビュー時にトリガーされる。原則に反するコードパターン（class使用、型アサーション、例外throw、PII未保護など）を検出し、修正案を提示する。
+
+## 参考記事
+
+これらの原則は以下の記事群に基づいている:
+
+- [複雑な状態遷移: クラスではなく関数とDiscriminated Unionで状態の定義と遷移を表現する](https://kosui.me/posts/2025/02/20/005900)
+- [Discriminated Unionを利用したStateパターンの実現](https://kosui.me/posts/2025/02/25/021320)
+- [TypeScriptでドメインイベントを容易に記録できるコード設計を考える](https://kosui.me/posts/2025/05/06/142842)
+- [なぜTypeScriptでメソッド記法を避けるべきか？](https://kosui.me/posts/2025/06/02/221656)
+- [私がTypeScriptで interface よりも type を好む理由](https://kosui.me/posts/2025/10/23/214710)
+- [ログのPII漏洩を防止する: TypeScriptの型推論とランタイムの境界](https://kosui.me/posts/2026/03/16/typescript-pii-logging-defense)
+- [サーバーサイドTypeScriptの型システムをどう教えるか](https://kakehashi-dev.hatenablog.com/entry/2026/03/31/110000)
+- [TypeScriptのテストにはas const satisfiesが便利です](https://kakehashi-dev.hatenablog.com/entry/2025/12/14/110000)
+- [TypeScriptの宣言的な配列操作](https://kakehashi-dev.hatenablog.com/entry/2025/11/19/110000)
+- [他言語経験者が知っておきたいTypeScriptのクラスの注意点](https://kakehashi-dev.hatenablog.com/entry/2025/08/19/110000)
+
+## ライセンス
+
+MIT

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "functional-ts-principal",
+  "version": "0.1.0",
+  "description": "Claude Code skill plugin: functional domain modeling principles for server-side TypeScript",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/iwasa-kosui/functional-ts-principal"
+  }
+}

--- a/skills/functional-ts-review/SKILL.md
+++ b/skills/functional-ts-review/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: functional-ts-review
+description: Use when reviewing TypeScript server-side code for adherence to functional domain modeling principles. Checks for class usage, method notation, interface declarations, type assertions, thrown exceptions, missing exhaustiveness checks, and PII protection.
+---
+
+# Functional TypeScript Code Review
+
+サーバーサイドTypeScriptコードを関数型ドメインモデリング原則に照らしてレビューする。
+
+## レビュー手順
+
+1. 変更対象のファイルを読む
+2. 以下のチェック項目を順にスキャンする
+3. 違反を発見した場合、原則と理由を添えて指摘する
+4. 違反ではないが改善余地がある場合は提案として伝える
+
+## チェック項目
+
+### 1. ドメインモデルにclassを使っていないか
+
+ドメインエンティティ・値オブジェクトの定義に `class` を使っている場合、Discriminated Union + Companion Objectパターンへの変更を提案する。
+
+外部ライブラリがclass継承を要求している場合は正当な逸脱。
+
+### 2. メソッド記法を使っていないか
+
+型定義内の関数がメソッド記法（`save(task: Task): Promise<void>`）になっている場合、関数プロパティ記法（`save: (task: Task) => Promise<void>`）への変更を指摘する。
+
+メソッド記法はパラメータ型がbivariantになり、依存注入時に狭い型の実装が型チェックを通過してしまう。
+
+### 3. ドメイン型に `interface` を使っていないか
+
+`interface` のdeclaration mergingは、別ファイルで同名のinterfaceを宣言するだけで型の形状が暗黙的に変わる。ドメイン型は `type` で定義する。
+
+ライブラリの型拡張（augmentation）には `interface` が必要。これは正当な用途。
+
+### 4. `as` による型アサーションがないか
+
+`as` は型チェックをバイパスする。以下を確認する:
+- 外部データ: Zodスキーマでパースしているか
+- Branded Type生成関数内の `as`: 許容（唯一の例外）
+- それ以外: 型推論で解決できないか検討
+
+### 5. ドメイン層で例外をthrowしていないか
+
+ドメイン層（エンティティ、ユースケース）で `throw` を使っている場合、`Result` 型への変更を提案する。
+
+以下は許容:
+- `assertNever` 内の throw（到達不能コードの検出）
+- インフラ層の予期しない障害
+
+### 6. switch文に assertNever があるか
+
+Discriminated Unionを `switch` で分岐している箇所に `default: return assertNever(x)` がない場合、追加を指摘する。新しいバリアントが追加されたときにコンパイルエラーで検出できなくなる。
+
+### 7. 外部境界にZodバリデーションがあるか
+
+APIハンドラ、DB結果の変換、設定ファイルの読み込みなど外部境界で、生のデータを型アサーションなしにドメイン型として扱っていないか確認する。
+
+### 8. PIIフィールドにSensitiveラッパーがあるか
+
+個人情報（氏名、メールアドレス、電話番号、診断情報など）を含むフィールドが `Sensitive<T>` でラップされているか確認する。特にログに出力される可能性のあるオブジェクトを重点的にチェックする。
+
+## 指摘の書き方
+
+各指摘には以下を含める:
+
+1. **何が問題か**: 具体的なコードの場所
+2. **なぜ問題か**: 原則と、違反した場合のリスク
+3. **どう直すか**: 修正案のコード例
+
+```
+### メソッド記法の使用
+
+`src/repository/task-repository.ts:15`
+
+`save(task: Task): Promise<void>` はメソッド記法です。メソッド記法ではパラメータ型がbivariantになり、
+`save(task: DoingTask): Promise<void>` のような狭い型の実装が型チェックを通過します。
+
+修正案:
+\`\`\`typescript
+type TaskRepository = {
+  save: (task: Task) => Promise<void>;
+};
+\`\`\`
+```
+
+## 重要度
+
+チェック項目には以下の重要度がある:
+
+| 重要度 | 項目 | 理由 |
+|--------|------|------|
+| High | `as` 型アサーション | ランタイムエラーの直接原因 |
+| High | PII未保護 | コンプライアンス違反リスク |
+| High | 外部境界のバリデーション不足 | ランタイムエラーの直接原因 |
+| Medium | class使用 | 拡張時の型安全性低下 |
+| Medium | throw使用 | エラーハンドリングの一貫性 |
+| Medium | assertNever不足 | 新バリアント追加時の見落とし |
+| Low | メソッド記法 | 特定条件下でのみ問題顕在化 |
+| Low | interface使用 | declaration merging事故は稀 |

--- a/skills/functional-ts/SKILL.md
+++ b/skills/functional-ts/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: functional-ts
+description: Use when writing server-side TypeScript code involving domain models, use cases, repositories, state transitions, or business logic. Guides functional domain modeling with discriminated unions, pure functions, and Result types.
+---
+
+# Functional Domain Modeling in TypeScript
+
+サーバーサイドTypeScriptでドメインモデルを書くときの原則。classベースのOOPではなく、TypeScriptの型システムを最大限に活用した関数型アプローチを採る。
+
+## 1. 型によるドメインモデリング
+
+### Discriminated Unionで状態を表現する
+
+ドメインエンティティの状態はclassではなくDiscriminated Unionで定義する。各状態を個別の型として定義し、状態固有のプロパティを必須にする。
+
+```typescript
+// Good: 各状態が独立した型。状態固有のプロパティが必須
+type Waiting = Readonly<{
+  kind: "Waiting";
+  passengerId: PassengerId;
+}>;
+
+type EnRoute = Readonly<{
+  kind: "EnRoute";
+  passengerId: PassengerId;
+  driverId: DriverId;
+}>;
+
+type TaxiRequest = Waiting | EnRoute | InTrip | Completed | Cancelled;
+```
+
+```typescript
+// Bad: optional プロパティで全状態を1つの型に押し込む
+type TaxiRequest = {
+  state: string;
+  passengerId: string;
+  driverId?: string;    // どの状態で存在するか不明
+  startTime?: Date;     // null チェックが至る所で必要
+  endTime?: Date;
+};
+```
+
+**理由:** optional プロパティは「どの状態でどのプロパティが存在するか」をコンパイル時に保証できない。Discriminated Unionなら、switch文でkindを判別した時点で状態固有のプロパティに安全にアクセスできる。
+
+### discriminantは `kind` で統一する
+
+プロジェクト全体で `kind` をdiscriminantプロパティ名として統一する。`type`, `status`, `state` などが混在するとコードベースの一貫性が損なわれる。
+
+### Companion Objectパターン
+
+型定義と関連する関数を同名のオブジェクトにまとめる。
+
+```typescript
+type TaxiRequest = Waiting | EnRoute | InTrip | Completed | Cancelled;
+
+const TaxiRequest = {
+  assignDriver: (waiting: Waiting, driverId: DriverId): EnRoute => ({
+    kind: "EnRoute",
+    passengerId: waiting.passengerId,
+    driverId,
+  }),
+
+  startTrip: (enRoute: EnRoute, startTime: Date): InTrip => ({
+    kind: "InTrip",
+    passengerId: enRoute.passengerId,
+    driverId: enRoute.driverId,
+    startTime,
+  }),
+
+  isActive: (request: TaxiRequest): request is Waiting | EnRoute | InTrip =>
+    request.kind !== "Completed" && request.kind !== "Cancelled",
+} as const;
+```
+
+### `type` を使う（`interface` ではなく）
+
+ドメイン型は `type` で定義する。`interface` のdeclaration mergingは、別ファイルで同名のinterfaceを宣言するだけで型の形状が暗黙的に変わる危険がある。
+
+```typescript
+// Good
+type User = Readonly<{
+  id: UserId;
+  name: string;
+}>;
+
+// Bad: 別ファイルで interface User { hashedPassword?: string } と宣言されると
+// 気づかないうちに型が変わる
+interface User {
+  id: string;
+  name: string;
+}
+```
+
+### 関数プロパティ記法を使う（メソッド記法ではなく）
+
+型定義内の関数はメソッド記法ではなく関数プロパティ記法で書く。メソッド記法はパラメータ型がbivariantになり、型安全性が崩れる。
+
+```typescript
+// Good: 関数プロパティ記法 — パラメータはcontravariant
+type TaskRepository = {
+  save: (task: Task) => Promise<void>;
+  findById: (id: TaskId) => Promise<Task | undefined>;
+};
+
+// Bad: メソッド記法 — パラメータがbivariantになり、
+// save(task: DoingTask) のような狭い実装が型チェックを通過してしまう
+type TaskRepository = {
+  save(task: Task): Promise<void>;
+  findById(id: TaskId): Promise<Task | undefined>;
+};
+```
+
+### Branded Typesで意味を区別する
+
+構造的部分型により `string` 同士は互換になる。意味の異なるIDや値にはBranded Typeを適用する。
+
+```typescript
+declare const UserIdBrand: unique symbol;
+type UserId = string & { readonly [UserIdBrand]: never };
+
+declare const ProductIdBrand: unique symbol;
+type ProductId = string & { readonly [ProductIdBrand]: never };
+
+// UserId と ProductId は構造的に非互換になる
+```
+
+### `Readonly<>` で不変性を保証する
+
+ドメインオブジェクトは `Readonly<>` で定義し、プロパティの再代入を防ぐ。状態変更は新しいオブジェクトの生成で表現する。
+
+## 2. 関数による状態遷移
+
+純粋関数で状態遷移を表現する。関数の引数型が有効な遷移元を制約し、戻り値型が遷移先を明示する。
+
+```typescript
+// assignDriver は Waiting 状態からのみ呼べる
+const assignDriver = (waiting: Waiting, driverId: DriverId): EnRoute => ({
+  kind: "EnRoute",
+  passengerId: waiting.passengerId,
+  driverId,
+});
+```
+
+無効な遷移（例: `assignDriver(completed, driverId)`）はコンパイルエラーになる。ランタイムチェックは不要。
+
+### 網羅性チェック
+
+switch文では `assertNever` を使い、すべてのケースを処理していることをコンパイル時に保証する。新しい状態が追加されたとき、未処理の箇所がコンパイルエラーで検出される。
+
+```typescript
+const assertNever = (x: never): never => {
+  throw new Error(`Unexpected value: ${JSON.stringify(x)}`);
+};
+
+const describe = (request: TaxiRequest): string => {
+  switch (request.kind) {
+    case "Waiting": return "Waiting for driver";
+    case "EnRoute": return `Driver ${request.driverId} en route`;
+    case "InTrip": return "In trip";
+    case "Completed": return "Completed";
+    case "Cancelled": return "Cancelled";
+    default: return assertNever(request);
+  }
+};
+```
+
+## 3. エラーハンドリング — Railway Oriented Programming
+
+例外をスローせず、`Result<T, E>` 型（neverthrow）でエラーを値として扱う。
+
+```typescript
+import { ok, err, Result } from "neverthrow";
+
+type AssignError =
+  | Readonly<{ kind: "DriverNotAvailable"; driverId: DriverId }>
+  | Readonly<{ kind: "RequestAlreadyAssigned" }>;
+
+const assignDriver = (
+  waiting: Waiting,
+  driverId: DriverId,
+  isAvailable: boolean,
+): Result<EnRoute, AssignError> => {
+  if (!isAvailable) {
+    return err({ kind: "DriverNotAvailable", driverId });
+  }
+  return ok({
+    kind: "EnRoute",
+    passengerId: waiting.passengerId,
+    driverId,
+  });
+};
+```
+
+`andThen` チェーンで処理を合成する。
+
+```typescript
+const processRequest = (requestId: RequestId) =>
+  findRequest(requestId)
+    .andThen(validateWaiting)
+    .andThen((waiting) => assignDriver(waiting, driverId, isAvailable))
+    .andThen(saveRequest);
+```
+
+エラー型もDiscriminated Unionで定義し、呼び出し元が網羅的にハンドルできるようにする。
+
+詳細: [error-handling.md](./error-handling.md)
+
+## 4. 境界の防御
+
+外部入力（APIリクエスト、DB結果、ファイル読み込み）はZodスキーマでランタイムバリデーションする。ドメイン層内部では型を信頼し、過剰な防御的バリデーションをしない。
+
+```typescript
+import { z } from "zod";
+
+const CreateRequestSchema = z.object({
+  passengerId: z.string().uuid().transform(PassengerId.of),
+});
+
+// API handler
+const handler = (req: Request) => {
+  const result = CreateRequestSchema.safeParse(req.body);
+  if (!result.success) return badRequest(result.error);
+  // result.data は型安全。以降 as は不要
+};
+```
+
+### 型アサーション（`as`）を使わない
+
+`as` は型チェックをバイパスし、ランタイムエラーの原因になる。外部データにはZodパース、内部データは型推論を信頼する。
+
+### PIIの防御
+
+個人情報を含むフィールドには `Sensitive<T>` ラッパーを適用し、`JSON.stringify` や `console.log` で自動的にマスクする。
+
+```typescript
+type Sensitive<T> = Readonly<{
+  unwrap: () => T;
+  toJSON: () => string;
+  toString: () => string;
+}>;
+
+const Sensitive = {
+  of: <T>(value: T): Sensitive<T> => ({
+    unwrap: () => value,
+    toJSON: () => "[REDACTED]",
+    toString: () => "[REDACTED]",
+    [Symbol.for("nodejs.util.inspect.custom")]: () => "[REDACTED]",
+  }),
+} as const;
+```
+
+Zodスキーマで自動ラップする。
+
+```typescript
+const sensitiveString = z.string().transform(Sensitive.of);
+
+const PatientSchema = z.object({
+  name: sensitiveString,
+  email: sensitiveString,
+  role: z.string(), // PIIではないのでそのまま
+});
+```
+
+詳細: [boundary-defense.md](./boundary-defense.md)
+
+## 5. 宣言的なスタイル
+
+### 配列操作
+
+配列の変換は `filter` / `map` / `reduce` で宣言的に書く。述語関数はCompanion Objectに定義する。
+
+```typescript
+type Task = ActiveTask | CompletedTask;
+
+const Task = {
+  isActive: (task: Task): task is ActiveTask => task.kind === "Active",
+} as const;
+
+// 宣言的: 「何をしたいか」が明確
+const activeTasks = tasks.filter(Task.isActive);
+
+// 命令的: ループの中身を読まないと意図がわからない
+const activeTasks: ActiveTask[] = [];
+for (const task of tasks) {
+  if (task.kind === "Active") activeTasks.push(task);
+}
+```
+
+### ドメインイベント
+
+状態変更に伴うドメインイベントは不変レコードとして生成し、リポジトリとは分離して記録する。
+
+```typescript
+type DomainEvent = Readonly<{
+  eventId: string;
+  eventAt: Date;
+  eventName: string;
+  payload: unknown;
+  aggregateId: string;
+}>;
+```
+
+詳細: [state-modeling.md](./state-modeling.md)
+
+## 6. テストデータ
+
+テストのダミーデータは `as const satisfies Type` で型安全に定義する。discriminantのリテラル型が保持され、wideningを防ぐ。
+
+```typescript
+const waitingRequest = {
+  kind: "Waiting",
+  passengerId: "passenger-1" as PassengerId,
+} as const satisfies Waiting;
+
+// waitingRequest.kind は "Waiting" リテラル型（string ではない）
+```
+
+## 原則の適用について
+
+これらは推奨であり厳格なルールではない。コンテキストに応じて判断してよいが、原則から逸脱する場合はその理由をコメントで明示すること。
+
+典型的な逸脱の正当理由:
+- 外部ライブラリがclass継承を要求する場合
+- パフォーマンス要件により不変データの生成コストが問題になる場合
+- チームの合意により異なるパターンが採用されている場合

--- a/skills/functional-ts/boundary-defense.md
+++ b/skills/functional-ts/boundary-defense.md
@@ -1,0 +1,149 @@
+# 境界防御の詳細ガイド
+
+## TypeScriptの型の限界を理解する
+
+TypeScriptの型はコンパイル時に消去される。ランタイムには型情報が残らないため、外部から入ってくるデータの正しさは型だけでは保証できない。
+
+構造的部分型により、余分なプロパティを持つオブジェクトは少ないプロパティの型に代入できる。これが意図しないデータ漏洩の原因になる。
+
+```typescript
+type LogPayload = { id: string; role: string };
+const user = { id: "1", role: "admin", email: "secret@example.com" };
+
+// 型チェックは通るが、emailがログに含まれる
+console.log(JSON.stringify(user satisfies LogPayload));
+```
+
+## Zodによるバリデーション
+
+外部境界（APIリクエスト、DB結果、環境変数、ファイル読み込み）ではZodスキーマでパースする。
+
+```typescript
+import { z } from "zod";
+
+const CreateRequestInput = z.object({
+  passengerId: z.string().uuid(),
+  pickupLocation: z.object({
+    lat: z.number().min(-90).max(90),
+    lng: z.number().min(-180).max(180),
+  }),
+});
+
+type CreateRequestInput = z.infer<typeof CreateRequestInput>;
+```
+
+### `safeParse` を使う
+
+`parse` は例外をスローする。Railway Oriented Programmingとの統合には `safeParse` を使い、結果をResult型に変換する。
+
+```typescript
+import { fromSafeParseReturnType } from "neverthrow-zod"; // or 手動変換
+
+const parseInput = (raw: unknown): Result<CreateRequestInput, ValidationError> => {
+  const result = CreateRequestInput.safeParse(raw);
+  if (result.success) return ok(result.data);
+  return err({ kind: "ValidationError", issues: result.error.issues });
+};
+```
+
+## 型アサーション（`as`）の禁止
+
+`as` は型チェックをバイパスする。外部データには Zod、内部データは型推論を信頼する。
+
+```typescript
+// Bad
+const user = data as User;
+
+// Good
+const user = UserSchema.parse(data);
+```
+
+唯一の例外は Branded Types の生成関数内。
+
+```typescript
+const UserId = {
+  of: (value: string): UserId => value as UserId, // ここだけ許容
+};
+```
+
+## Sensitive型によるPII防御
+
+### 問題
+
+TypeScriptの型はランタイムで消えるため、型で「PIIだ」とマークしても `JSON.stringify` や `console.log` で漏洩する。Branded Typeでも変数代入時にブランドが失われる。
+
+### 解決策: クロージャベースのラッパー
+
+値を関数クロージャに閉じ込め、シリアライズ時に自動マスクする。
+
+```typescript
+type Sensitive<T> = Readonly<{
+  unwrap: () => T;
+  toJSON: () => string;
+  toString: () => string;
+}>;
+
+const Sensitive = {
+  of: <T>(value: T): Sensitive<T> => ({
+    unwrap: () => value,
+    toJSON: () => "[REDACTED]",
+    toString: () => "[REDACTED]",
+    [Symbol.for("nodejs.util.inspect.custom")]: () => "[REDACTED]",
+  }),
+} as const;
+```
+
+### Zodとの統合
+
+パース時に自動でSensitiveラップする。
+
+```typescript
+const sensitiveString = z.string().transform(Sensitive.of);
+
+const PatientSchema = z.object({
+  id: z.string().uuid(),
+  name: sensitiveString,
+  email: sensitiveString,
+  diagnosis: sensitiveString,
+  role: z.string(), // PIIではない
+});
+
+const patient = PatientSchema.parse(rawData);
+console.log(JSON.stringify(patient));
+// {"id":"...","name":"[REDACTED]","email":"[REDACTED]","diagnosis":"[REDACTED]","role":"doctor"}
+```
+
+### 多層防御: Pinoのredaction
+
+Sensitiveラッパーの適用漏れに備え、ロガーレベルでもredactionを設定する。
+
+```typescript
+import pino from "pino";
+
+const logger = pino({
+  redact: {
+    paths: ["email", "*.email", "password", "*.password", "name", "*.name"],
+    censor: "[REDACTED]",
+  },
+});
+```
+
+## ドメイン内部では過剰防御しない
+
+外部境界でバリデーション済みのデータは、ドメイン層内部で再度バリデーションしない。型を信頼する。
+
+```typescript
+// Bad: ドメイン層で冗長なチェック
+const assignDriver = (waiting: Waiting, driverId: DriverId): EnRoute => {
+  if (waiting.kind !== "Waiting") throw new Error("Invalid state"); // 型が保証している
+  if (!driverId) throw new Error("Missing driverId"); // 型が保証している
+  return { kind: "EnRoute", passengerId: waiting.passengerId, driverId };
+};
+
+// Good: 型を信頼する
+const assignDriver = (waiting: Waiting, driverId: DriverId): EnRoute => ({
+  kind: "EnRoute",
+  passengerId: waiting.passengerId,
+  driverId,
+});
+```

--- a/skills/functional-ts/error-handling.md
+++ b/skills/functional-ts/error-handling.md
@@ -1,0 +1,95 @@
+# エラーハンドリング詳細ガイド
+
+## Railway Oriented Programming
+
+neverthrow の `Result<T, E>` を使い、成功と失敗を型で表現する。例外のthrowはドメイン層では使わない。
+
+## エラー型の設計
+
+エラーもDiscriminated Unionで定義し、呼び出し元が網羅的にハンドルできるようにする。
+
+```typescript
+type AssignDriverError =
+  | Readonly<{ kind: "RequestNotFound"; requestId: RequestId }>
+  | Readonly<{ kind: "InvalidState"; currentKind: string; expectedKind: "Waiting" }>
+  | Readonly<{ kind: "DriverNotAvailable"; driverId: DriverId }>;
+```
+
+### エラー型の粒度
+
+各ユースケースが返すエラー型は、そのユースケース固有のものにする。共通のエラー型（`AppError`）にすべてを詰め込むと、呼び出し元が「実際にはどのエラーが起こりうるか」を型から判断できなくなる。
+
+```typescript
+// Good: ユースケース固有のエラー型
+type AssignDriverError = RequestNotFoundError | InvalidStateError | DriverNotAvailableError;
+type StartTripError = RequestNotFoundError | InvalidStateError;
+
+// Bad: 全エラーを1つに詰め込む
+type AppError = RequestNotFoundError | InvalidStateError | DriverNotAvailableError | ...;
+```
+
+## andThen チェーン
+
+処理の合成は `andThen` で行う。各ステップが `Result` を返し、エラーが発生した時点で後続のステップはスキップされる。
+
+```typescript
+const assignDriverUseCase = (
+  requestId: RequestId,
+  driverId: DriverId,
+): ResultAsync<EnRoute, AssignDriverError> =>
+  requestRepository
+    .findById(requestId)
+    .andThen(ensureFound(requestId))
+    .andThen(ensureWaiting)
+    .andThen((waiting) => checkDriverAvailability(driverId).map(() => waiting))
+    .andThen((waiting) => {
+      const enRoute = TaxiRequest.assignDriver(waiting, driverId);
+      return requestRepository.save(enRoute).map(() => enRoute);
+    });
+```
+
+### ヘルパー関数
+
+共通のバリデーションは小さな関数に切り出す。
+
+```typescript
+const ensureFound = <T>(id: RequestId) => (
+  value: T | undefined,
+): Result<T, RequestNotFoundError> =>
+  value !== undefined
+    ? ok(value)
+    : err({ kind: "RequestNotFound", requestId: id });
+
+const ensureWaiting = (
+  request: TaxiRequest,
+): Result<Waiting, InvalidStateError> =>
+  request.kind === "Waiting"
+    ? ok(request)
+    : err({ kind: "InvalidState", currentKind: request.kind, expectedKind: "Waiting" });
+```
+
+## Controller層でのエラー変換
+
+ドメインエラーをHTTPレスポンスに変換するのはController層の責務。ドメインエラーのkindに基づいてステータスコードを決定する。
+
+```typescript
+const toHttpResponse = (error: AssignDriverError): Response => {
+  switch (error.kind) {
+    case "RequestNotFound":
+      return notFound(`Request ${error.requestId} not found`);
+    case "InvalidState":
+      return conflict(`Expected ${error.expectedKind}, got ${error.currentKind}`);
+    case "DriverNotAvailable":
+      return unprocessableEntity(`Driver ${error.driverId} is not available`);
+    default:
+      return assertNever(error);
+  }
+};
+```
+
+## 例外を使うべき場所
+
+ドメイン層では例外をスローしないが、以下の場所では例外が適切:
+
+- `assertNever`: 到達不能コードの検出（プログラムのバグ）
+- インフラ層の予期しない障害（DB接続断など）— これはフレームワークのエラーハンドラに任せる

--- a/skills/functional-ts/examples/domain-event.ts
+++ b/skills/functional-ts/examples/domain-event.ts
@@ -1,0 +1,114 @@
+/**
+ * ドメインイベントの記録パターンの実例
+ *
+ * 状態遷移に伴うイベントをユースケース層で生成し、
+ * リポジトリとは分離して保存する。
+ */
+
+import { ok, err, Result, ResultAsync } from "neverthrow";
+
+// --- Branded Types ---
+
+declare const RequestIdBrand: unique symbol;
+type RequestId = string & { readonly [RequestIdBrand]: never };
+
+declare const DriverIdBrand: unique symbol;
+type DriverId = string & { readonly [DriverIdBrand]: never };
+
+declare const PassengerIdBrand: unique symbol;
+type PassengerId = string & { readonly [PassengerIdBrand]: never };
+
+// --- Domain Event ---
+
+type DomainEvent<TName extends string, TPayload> = Readonly<{
+  eventId: string;
+  eventAt: Date;
+  eventName: TName;
+  payload: TPayload;
+  aggregateId: string;
+  aggregateName: string;
+}>;
+
+type DriverAssignedEvent = DomainEvent<
+  "DriverAssigned",
+  Readonly<{ driverId: DriverId; passengerId: PassengerId }>
+>;
+
+// --- State Types (simplified) ---
+
+type Waiting = Readonly<{
+  kind: "Waiting";
+  requestId: RequestId;
+  passengerId: PassengerId;
+}>;
+
+type EnRoute = Readonly<{
+  kind: "EnRoute";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  driverId: DriverId;
+}>;
+
+// --- Repository Types (function property notation) ---
+
+type RequestRepository = {
+  findById: (id: RequestId) => ResultAsync<Waiting | undefined, RepositoryError>;
+  save: (request: EnRoute) => ResultAsync<void, RepositoryError>;
+};
+
+type EventStore = {
+  save: (event: DriverAssignedEvent) => ResultAsync<void, RepositoryError>;
+};
+
+// --- Error Types ---
+
+type AssignDriverError =
+  | Readonly<{ kind: "RequestNotFound"; requestId: RequestId }>
+  | Readonly<{ kind: "DriverNotAvailable"; driverId: DriverId }>
+  | Readonly<{ kind: "RepositoryError"; cause: unknown }>;
+
+type RepositoryError = Readonly<{ kind: "RepositoryError"; cause: unknown }>;
+
+// --- Use Case ---
+
+const assignDriverUseCase =
+  (requestRepo: RequestRepository, eventStore: EventStore) =>
+  (
+    requestId: RequestId,
+    driverId: DriverId,
+    isDriverAvailable: boolean,
+    now: Date,
+  ): ResultAsync<EnRoute, AssignDriverError> =>
+    requestRepo
+      .findById(requestId)
+      .andThen((request) =>
+        request !== undefined
+          ? ok(request)
+          : err({ kind: "RequestNotFound" as const, requestId }),
+      )
+      .andThen((waiting) => {
+        if (!isDriverAvailable) {
+          return err({ kind: "DriverNotAvailable" as const, driverId });
+        }
+
+        const enRoute: EnRoute = {
+          kind: "EnRoute",
+          requestId: waiting.requestId,
+          passengerId: waiting.passengerId,
+          driverId,
+        };
+
+        const event: DriverAssignedEvent = {
+          eventId: crypto.randomUUID(),
+          eventAt: now,
+          eventName: "DriverAssigned",
+          payload: { driverId, passengerId: waiting.passengerId },
+          aggregateId: waiting.requestId,
+          aggregateName: "TaxiRequest",
+        };
+
+        return requestRepo
+          .save(enRoute)
+          .andThen(() => eventStore.save(event))
+          .map(() => enRoute);
+      });

--- a/skills/functional-ts/examples/sensitive-type.ts
+++ b/skills/functional-ts/examples/sensitive-type.ts
@@ -1,0 +1,58 @@
+/**
+ * Sensitive型ラッパーによるPII防御の実例
+ *
+ * クロージャに値を閉じ込め、JSON.stringify / console.log / template literal で
+ * 自動的にマスクする。Zodとの統合でパース時に自動ラップする。
+ */
+
+import { z } from "zod";
+
+// --- Sensitive Type ---
+
+type Sensitive<T> = Readonly<{
+  unwrap: () => T;
+  toJSON: () => string;
+  toString: () => string;
+}>;
+
+const Sensitive = {
+  of: <T>(value: T): Sensitive<T> => ({
+    unwrap: () => value,
+    toJSON: () => "[REDACTED]",
+    toString: () => "[REDACTED]",
+    [Symbol.for("nodejs.util.inspect.custom")]: () => "[REDACTED]",
+  }),
+} as const;
+
+// --- Zod Integration ---
+
+const sensitiveString = z.string().transform(Sensitive.of);
+
+const PatientSchema = z.object({
+  id: z.string().uuid(),
+  name: sensitiveString,
+  email: sensitiveString,
+  diagnosis: sensitiveString,
+  role: z.string(),
+});
+
+type Patient = z.infer<typeof PatientSchema>;
+
+// --- Usage ---
+
+const rawData = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  name: "John Doe",
+  email: "john@example.com",
+  diagnosis: "Hypertension",
+  role: "outpatient",
+};
+
+const patient: Patient = PatientSchema.parse(rawData);
+
+// Safe: PII is masked
+// {"id":"550e8400-...","name":"[REDACTED]","email":"[REDACTED]","diagnosis":"[REDACTED]","role":"outpatient"}
+console.log(JSON.stringify(patient));
+
+// Access actual value only when explicitly needed
+const actualEmail: string = patient.email.unwrap();

--- a/skills/functional-ts/examples/taxi-request.ts
+++ b/skills/functional-ts/examples/taxi-request.ts
@@ -1,0 +1,137 @@
+/**
+ * タクシー配車リクエストの状態遷移モデル
+ *
+ * Discriminated Union + Companion Object + 純粋関数による状態遷移の実例。
+ * 無効な遷移はコンパイルエラーで検出される。
+ */
+
+// --- Branded Types ---
+
+declare const PassengerIdBrand: unique symbol;
+type PassengerId = string & { readonly [PassengerIdBrand]: never };
+
+declare const DriverIdBrand: unique symbol;
+type DriverId = string & { readonly [DriverIdBrand]: never };
+
+declare const RequestIdBrand: unique symbol;
+type RequestId = string & { readonly [RequestIdBrand]: never };
+
+// --- State Types ---
+
+type Waiting = Readonly<{
+  kind: "Waiting";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  createdAt: Date;
+}>;
+
+type EnRoute = Readonly<{
+  kind: "EnRoute";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  driverId: DriverId;
+  assignedAt: Date;
+}>;
+
+type InTrip = Readonly<{
+  kind: "InTrip";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  driverId: DriverId;
+  startedAt: Date;
+}>;
+
+type Completed = Readonly<{
+  kind: "Completed";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  driverId: DriverId;
+  startedAt: Date;
+  completedAt: Date;
+}>;
+
+type Cancelled = Readonly<{
+  kind: "Cancelled";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  cancelledAt: Date;
+  reason: string;
+}>;
+
+// --- Union Type ---
+
+type TaxiRequest = Waiting | EnRoute | InTrip | Completed | Cancelled;
+type CancellableRequest = Waiting | EnRoute | InTrip;
+
+// --- Companion Object ---
+
+const assertNever = (x: never): never => {
+  throw new Error(`Unexpected value: ${JSON.stringify(x)}`);
+};
+
+const TaxiRequest = {
+  create: (requestId: RequestId, passengerId: PassengerId, now: Date): Waiting => ({
+    kind: "Waiting",
+    requestId,
+    passengerId,
+    createdAt: now,
+  }),
+
+  assignDriver: (waiting: Waiting, driverId: DriverId, now: Date): EnRoute => ({
+    kind: "EnRoute",
+    requestId: waiting.requestId,
+    passengerId: waiting.passengerId,
+    driverId,
+    assignedAt: now,
+  }),
+
+  startTrip: (enRoute: EnRoute, now: Date): InTrip => ({
+    kind: "InTrip",
+    requestId: enRoute.requestId,
+    passengerId: enRoute.passengerId,
+    driverId: enRoute.driverId,
+    startedAt: now,
+  }),
+
+  complete: (inTrip: InTrip, now: Date): Completed => ({
+    kind: "Completed",
+    requestId: inTrip.requestId,
+    passengerId: inTrip.passengerId,
+    driverId: inTrip.driverId,
+    startedAt: inTrip.startedAt,
+    completedAt: now,
+  }),
+
+  cancel: (request: CancellableRequest, reason: string, now: Date): Cancelled => ({
+    kind: "Cancelled",
+    requestId: request.requestId,
+    passengerId: request.passengerId,
+    cancelledAt: now,
+    reason,
+  }),
+
+  isCancellable: (request: TaxiRequest): request is CancellableRequest =>
+    request.kind === "Waiting" ||
+    request.kind === "EnRoute" ||
+    request.kind === "InTrip",
+
+  isTerminal: (request: TaxiRequest): request is Completed | Cancelled =>
+    request.kind === "Completed" || request.kind === "Cancelled",
+
+  describe: (request: TaxiRequest): string => {
+    switch (request.kind) {
+      case "Waiting":
+        return `Waiting (created ${request.createdAt.toISOString()})`;
+      case "EnRoute":
+        return `Driver ${request.driverId} en route`;
+      case "InTrip":
+        return `In trip since ${request.startedAt.toISOString()}`;
+      case "Completed":
+        return `Completed at ${request.completedAt.toISOString()}`;
+      case "Cancelled":
+        return `Cancelled: ${request.reason}`;
+      default:
+        return assertNever(request);
+    }
+  },
+} as const;

--- a/skills/functional-ts/state-modeling.md
+++ b/skills/functional-ts/state-modeling.md
@@ -1,0 +1,171 @@
+# 状態モデリング詳細ガイド
+
+## Discriminated Unionによる状態遷移の設計
+
+### 設計手順
+
+1. ドメインエンティティが取りうる状態を列挙する
+2. 各状態で必要なプロパティを特定する
+3. 状態ごとに個別の型を定義する（`kind` をdiscriminant）
+4. Union型でまとめる
+5. 有効な遷移を純粋関数として定義する
+6. Companion Objectに関数をまとめる
+
+### 状態遷移図からコードへ
+
+```
+Waiting → EnRoute → InTrip → Completed
+  ↓         ↓        ↓
+Cancelled Cancelled Cancelled
+```
+
+この遷移図は以下のように型と関数に変換される。
+
+```typescript
+// 1. 各状態の型
+type Waiting = Readonly<{
+  kind: "Waiting";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  createdAt: Date;
+}>;
+
+type EnRoute = Readonly<{
+  kind: "EnRoute";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  driverId: DriverId;
+  assignedAt: Date;
+}>;
+
+type InTrip = Readonly<{
+  kind: "InTrip";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  driverId: DriverId;
+  startedAt: Date;
+}>;
+
+type Completed = Readonly<{
+  kind: "Completed";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  driverId: DriverId;
+  startedAt: Date;
+  completedAt: Date;
+}>;
+
+type Cancelled = Readonly<{
+  kind: "Cancelled";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  cancelledAt: Date;
+  reason: string;
+}>;
+
+// 2. Union型
+type TaxiRequest = Waiting | EnRoute | InTrip | Completed | Cancelled;
+
+// 3. Cancellable な状態のUnion（部分的なUnionも活用する）
+type CancellableRequest = Waiting | EnRoute | InTrip;
+
+// 4. 遷移関数
+const TaxiRequest = {
+  assignDriver: (waiting: Waiting, driverId: DriverId, now: Date): EnRoute => ({
+    kind: "EnRoute",
+    requestId: waiting.requestId,
+    passengerId: waiting.passengerId,
+    driverId,
+    assignedAt: now,
+  }),
+
+  startTrip: (enRoute: EnRoute, now: Date): InTrip => ({
+    kind: "InTrip",
+    requestId: enRoute.requestId,
+    passengerId: enRoute.passengerId,
+    driverId: enRoute.driverId,
+    startedAt: now,
+  }),
+
+  complete: (inTrip: InTrip, now: Date): Completed => ({
+    kind: "Completed",
+    requestId: inTrip.requestId,
+    passengerId: inTrip.passengerId,
+    driverId: inTrip.driverId,
+    startedAt: inTrip.startedAt,
+    completedAt: now,
+  }),
+
+  cancel: (request: CancellableRequest, reason: string, now: Date): Cancelled => ({
+    kind: "Cancelled",
+    requestId: request.requestId,
+    passengerId: request.passengerId,
+    cancelledAt: now,
+    reason,
+  }),
+
+  isCancellable: (request: TaxiRequest): request is CancellableRequest =>
+    request.kind === "Waiting" ||
+    request.kind === "EnRoute" ||
+    request.kind === "InTrip",
+} as const;
+```
+
+### 注意点
+
+**共通プロパティの扱い:** `requestId` や `passengerId` のように全状態に共通するプロパティがあっても、base typeを `extends` で継承するのは避ける。`interface` の継承は前述のdeclaration merging問題を持ち込む。各状態で明示的にプロパティを定義する冗長さは、型安全性とのトレードオフとして受け入れる。
+
+**日時の生成:** 上記例では日時を引数として受け取る設計にしている。これによりテストで任意の時刻を注入でき、テスタビリティが確保される。
+
+## ドメインイベント
+
+状態遷移に伴うビジネス上の出来事をドメインイベントとして記録する。イベントはリポジトリとは別のストアに保存する。
+
+```typescript
+type DomainEvent<TName extends string, TPayload> = Readonly<{
+  eventId: string;
+  eventAt: Date;
+  eventName: TName;
+  payload: TPayload;
+  aggregateId: string;
+  aggregateName: string;
+}>;
+
+type DriverAssignedEvent = DomainEvent<
+  "DriverAssigned",
+  { driverId: DriverId; passengerId: PassengerId }
+>;
+
+type TripCompletedEvent = DomainEvent<
+  "TripCompleted",
+  { driverId: DriverId; duration: number }
+>;
+```
+
+### イベント生成の責務
+
+ユースケース層がイベントを生成し、リポジトリにはエンティティとイベントを別々に渡す。リポジトリがイベントを生成する設計は責務が肥大化する。
+
+```typescript
+const assignDriverUseCase = (
+  requestId: RequestId,
+  driverId: DriverId,
+) =>
+  findRequest(requestId)
+    .andThen(validateWaiting)
+    .map((waiting) => {
+      const enRoute = TaxiRequest.assignDriver(waiting, driverId);
+      const event: DriverAssignedEvent = {
+        eventId: crypto.randomUUID(),
+        eventAt: new Date(),
+        eventName: "DriverAssigned",
+        payload: { driverId, passengerId: waiting.passengerId },
+        aggregateId: waiting.requestId,
+        aggregateName: "TaxiRequest",
+      };
+      return { entity: enRoute, event };
+    })
+    .andThen(({ entity, event }) =>
+      saveRequest(entity).andThen(() => saveEvent(event))
+    );
+```


### PR DESCRIPTION
## Why

The functional domain modeling principles for server-side TypeScript, systematized through blog posts on kosui.me, needed to be provided in a reusable form for coding agents. Currently these principles are scattered across blog articles and must be manually communicated per project.

## What

Provides two skills as a Claude Code skill plugin:

- **functional-ts**: Automatically triggered during coding, guiding 6 categories of principles including Discriminated Unions, pure function state transitions, Result types, Zod boundary defense, Sensitive type for PII protection, and as const satisfies
- **functional-ts-review**: Triggered during review, checking 8 items including class usage, method notation, type assertions, thrown exceptions, missing assertNever, and unprotected PII

Principles are at the "recommended" level, allowing context-dependent deviations.

## Test Plan

- [ ] Verify skills appear in skill list after local install
- [ ] Verify functional-ts skill triggers when writing TypeScript domain models
- [ ] Verify functional-ts-review skill flags code violating the principles

---
Generated with Claude Code
