### PR TITLE
refactor(skill): rewrite neverthrow/fp-ts examples to ROP pipeline composition

### DIFF
--- a/skills/functional-ts/result-libraries/fp-ts.md
+++ b/skills/functional-ts/result-libraries/fp-ts.md
@@ -14,6 +14,10 @@ import { pipe } from "fp-ts/function";
 | `TaskEither<E, A>` | 非同期Result型（`() => Promise<Either<E, A>>`） |
 | `E.right(value)` | 成功値を生成 |
 | `E.left(error)` | 失敗値を生成 |
+| `TE.Do` | `TaskEither<never, {}>` を生成。`bind` と組み合わせてオブジェクトを段階的に構築する起点 |
+| `TE.bind(name, fn)` | 成功値のオブジェクトに `fn` の結果を `name` キーで追加 |
+| `TE.chainFirst(fn)` | 副作用を実行し、成功なら元の値を維持して返す |
+| `TE.chainEitherK(fn)` | 同期の `Either` を返す関数を `TaskEither` チェーンに組み込む |
 
 ## パイプによる合成
 
@@ -25,14 +29,26 @@ pipe(
   E.map((a) => transform(a)),           // 成功値を変換
   E.mapLeft((e) => transformErr(e)),     // エラー値を変換
   E.chain((a) => nextEither(a)),         // 成功値から次のEitherへ（flatMap）
+  E.chainFirst((a) => sideEffect(a)),   // 副作用を実行し、成功なら元の値を維持
   E.fold(
     (error) => handleErr(error),
     (value) => handleOk(value),
   ),
 );
+
+// Do + bind: オブジェクトを段階的に組み立てる
+pipe(
+  TE.Do,                                              // TaskEither<never, {}> から開始
+  TE.bind("user", () => findUser(userId)),            // { user: User }
+  TE.bind("order", ({ user }) => findOrder(user)),    // { user: User, order: Order }
+  TE.chainFirst(({ order }) => validate(order)),      // バリデーション（値は維持）
+  TE.map(({ user, order }) => buildResponse(user, order)),
+);
 ```
 
 ## コード例: ドメインイベントの記録
+
+Railway Oriented Programmingの原則に従い、各処理を独立した関数に切り出し、ユースケースは `pipe` + `Do`/`bind`/`chainFirst` でそれらを合成するだけにする。
 
 ```typescript
 import * as E from "fp-ts/Either";
@@ -101,7 +117,54 @@ type AssignDriverError =
 
 type RepositoryError = Readonly<{ kind: "RepositoryError"; cause: unknown }>;
 
-// --- Use Case ---
+// --- Domain Functions ---
+
+const ensureExists =
+  (requestId: RequestId) =>
+  (request: Waiting | undefined): E.Either<AssignDriverError, Waiting> =>
+    request !== undefined
+      ? E.right(request)
+      : E.left({ kind: "RequestNotFound", requestId });
+
+const ensureDriverAvailable =
+  (driverId: DriverId, isAvailable: boolean) =>
+  (): E.Either<AssignDriverError, DriverId> =>
+    isAvailable
+      ? E.right(driverId)
+      : E.left({ kind: "DriverNotAvailable", driverId });
+
+const transitionToEnRoute = (ctx: {
+  waiting: Waiting;
+  driverId: DriverId;
+}): EnRoute => ({
+  kind: "EnRoute",
+  requestId: ctx.waiting.requestId,
+  passengerId: ctx.waiting.passengerId,
+  driverId: ctx.driverId,
+});
+
+const buildDriverAssignedEvent =
+  (now: Date) =>
+  (enRoute: EnRoute): DriverAssignedEvent => ({
+    eventId: crypto.randomUUID(),
+    eventAt: now,
+    eventName: "DriverAssigned",
+    payload: { driverId: enRoute.driverId, passengerId: enRoute.passengerId },
+    aggregateId: enRoute.requestId,
+    aggregateName: "TaxiRequest",
+  });
+
+const persistEnRoute =
+  (requestRepo: RequestRepository) =>
+  (enRoute: EnRoute): TE.TaskEither<AssignDriverError, void> =>
+    requestRepo.save(enRoute);
+
+const publishEvent =
+  (eventStore: EventStore) =>
+  (event: DriverAssignedEvent): TE.TaskEither<AssignDriverError, void> =>
+    eventStore.save(event);
+
+// --- Use Case (Do + bind による完全パイプライン合成) ---
 
 const assignDriverUseCase =
   (requestRepo: RequestRepository, eventStore: EventStore) =>
@@ -112,38 +175,25 @@ const assignDriverUseCase =
     now: Date,
   ): TE.TaskEither<AssignDriverError, EnRoute> =>
     pipe(
-      requestRepo.findById(requestId),
-      TE.chain((request) =>
-        request !== undefined
-          ? TE.right(request)
-          : TE.left({ kind: "RequestNotFound" as const, requestId }),
+      TE.Do,
+      // 1. リクエスト取得 → 存在確認
+      TE.bind("waiting", () =>
+        pipe(
+          requestRepo.findById(requestId),
+          TE.chainEitherK(ensureExists(requestId)),
+        ),
       ),
-      TE.chain((waiting) => {
-        if (!isDriverAvailable) {
-          return TE.left({ kind: "DriverNotAvailable" as const, driverId });
-        }
-
-        const enRoute: EnRoute = {
-          kind: "EnRoute",
-          requestId: waiting.requestId,
-          passengerId: waiting.passengerId,
-          driverId,
-        };
-
-        const event: DriverAssignedEvent = {
-          eventId: crypto.randomUUID(),
-          eventAt: now,
-          eventName: "DriverAssigned",
-          payload: { driverId, passengerId: waiting.passengerId },
-          aggregateId: waiting.requestId,
-          aggregateName: "TaxiRequest",
-        };
-
-        return pipe(
-          requestRepo.save(enRoute),
-          TE.chain(() => eventStore.save(event)),
-          TE.map(() => enRoute),
-        );
-      }),
+      // 2. ドライバーの空き確認
+      TE.bind("driverId", () =>
+        TE.fromEither(ensureDriverAvailable(driverId, isDriverAvailable)()),
+      ),
+      // 3. 状態遷移
+      TE.map(transitionToEnRoute),
+      // 4. 永続化（chainFirst で enRoute を維持）
+      TE.chainFirst(persistEnRoute(requestRepo)),
+      // 5. ドメインイベント発行（chainFirst で enRoute を維持）
+      TE.chainFirst((enRoute) =>
+        publishEvent(eventStore)(buildDriverAssignedEvent(now)(enRoute)),
+      ),
     );
 ```

--- a/skills/functional-ts/result-libraries/neverthrow.md
+++ b/skills/functional-ts/result-libraries/neverthrow.md
@@ -12,15 +12,17 @@ import { ok, err, Result, ResultAsync } from "neverthrow";
 | `ResultAsync<T, E>` | 非同期Result型（Promise<Result>のラッパー） |
 | `ok(value)` | 成功値を生成 |
 | `err(error)` | 失敗値を生成 |
+| `.andThrough(fn)` | 副作用を実行し、成功なら元の値を維持して返す |
 
 ## チェーンメソッド
 
 ```typescript
 result
-  .map((value) => transform(value))       // 成功値を変換
-  .mapErr((error) => transformErr(error))  // エラー値を変換
-  .andThen((value) => nextResult(value))   // 成功値から次のResultへ（flatMap）
-  .orElse((error) => recover(error))       // エラーから回復
+  .map((value) => transform(value))         // 成功値を変換
+  .mapErr((error) => transformErr(error))    // エラー値を変換
+  .andThen((value) => nextResult(value))     // 成功値から次のResultへ（flatMap）
+  .andThrough((value) => sideEffect(value))  // 副作用を実行し、成功なら元の値を維持
+  .orElse((error) => recover(error))         // エラーから回復
   .match(
     (value) => handleOk(value),
     (error) => handleErr(error),
@@ -28,6 +30,8 @@ result
 ```
 
 ## コード例: ドメインイベントの記録
+
+Railway Oriented Programmingの原則に従い、各処理を独立した関数に切り出し、ユースケースはメソッドチェーンでそれらを合成するだけにする。`andThrough` で副作用を挟みつつ元の値を維持する。
 
 ```typescript
 import { ok, err, Result, ResultAsync } from "neverthrow";
@@ -94,7 +98,53 @@ type AssignDriverError =
 
 type RepositoryError = Readonly<{ kind: "RepositoryError"; cause: unknown }>;
 
-// --- Use Case ---
+// --- Domain Functions ---
+
+const ensureExists =
+  (requestId: RequestId) =>
+  (request: Waiting | undefined): Result<Waiting, AssignDriverError> =>
+    request !== undefined
+      ? ok(request)
+      : err({ kind: "RequestNotFound", requestId });
+
+const ensureDriverAvailable =
+  (driverId: DriverId, isAvailable: boolean) =>
+  (waiting: Waiting): Result<Waiting, AssignDriverError> =>
+    isAvailable
+      ? ok(waiting)
+      : err({ kind: "DriverNotAvailable", driverId });
+
+const transitionToEnRoute =
+  (driverId: DriverId) =>
+  (waiting: Waiting): EnRoute => ({
+    kind: "EnRoute",
+    requestId: waiting.requestId,
+    passengerId: waiting.passengerId,
+    driverId,
+  });
+
+const buildDriverAssignedEvent =
+  (now: Date) =>
+  (enRoute: EnRoute): DriverAssignedEvent => ({
+    eventId: crypto.randomUUID(),
+    eventAt: now,
+    eventName: "DriverAssigned",
+    payload: { driverId: enRoute.driverId, passengerId: enRoute.passengerId },
+    aggregateId: enRoute.requestId,
+    aggregateName: "TaxiRequest",
+  });
+
+const persistEnRoute =
+  (requestRepo: RequestRepository) =>
+  (enRoute: EnRoute): ResultAsync<void, AssignDriverError> =>
+    requestRepo.save(enRoute);
+
+const publishEvent =
+  (eventStore: EventStore) =>
+  (event: DriverAssignedEvent): ResultAsync<void, AssignDriverError> =>
+    eventStore.save(event);
+
+// --- Use Case (andThrough によるパイプライン合成) ---
 
 const assignDriverUseCase =
   (requestRepo: RequestRepository, eventStore: EventStore) =>
@@ -106,35 +156,11 @@ const assignDriverUseCase =
   ): ResultAsync<EnRoute, AssignDriverError> =>
     requestRepo
       .findById(requestId)
-      .andThen((request) =>
-        request !== undefined
-          ? ok(request)
-          : err({ kind: "RequestNotFound" as const, requestId }),
-      )
-      .andThen((waiting) => {
-        if (!isDriverAvailable) {
-          return err({ kind: "DriverNotAvailable" as const, driverId });
-        }
-
-        const enRoute: EnRoute = {
-          kind: "EnRoute",
-          requestId: waiting.requestId,
-          passengerId: waiting.passengerId,
-          driverId,
-        };
-
-        const event: DriverAssignedEvent = {
-          eventId: crypto.randomUUID(),
-          eventAt: now,
-          eventName: "DriverAssigned",
-          payload: { driverId, passengerId: waiting.passengerId },
-          aggregateId: waiting.requestId,
-          aggregateName: "TaxiRequest",
-        };
-
-        return requestRepo
-          .save(enRoute)
-          .andThen(() => eventStore.save(event))
-          .map(() => enRoute);
-      });
+      .andThen(ensureExists(requestId))
+      .andThen(ensureDriverAvailable(driverId, isDriverAvailable))
+      .map(transitionToEnRoute(driverId))
+      .andThrough(persistEnRoute(requestRepo))
+      .andThrough((enRoute) =>
+        publishEvent(eventStore)(buildDriverAssignedEvent(now)(enRoute)),
+      );
 ```


### PR DESCRIPTION
## Why

The byethrow code example had been rewritten to a full ROP pipeline, but neverthrow and fp-ts examples still had inline procedural logic within use cases. The three libraries were inconsistent in how they demonstrated ROP.

## What

- neverthrow: Rewrote using andThrough to chain side effects (persistence, event publishing) while preserving the original value
- fp-ts: Rewrote to complete pipeline composition using Do + bind + chainFirst
- Both libraries: Extracted each operation into independent functions, with use cases only performing orchestration
- Added andThrough (neverthrow) and Do/bind/chainFirst/chainEitherK (fp-ts) to basic API tables

## Test Plan

- [ ] Verify neverthrow/fp-ts code examples pass TypeScript type checking
- [ ] Verify API names and signatures match official documentation

---
Generated with Claude Code
