### PR TITLE
docs(skill): add z.brand() recommendation, companion .schema, and one-concept-per-file guideline

### DIFF
--- a/skills/functional-ts/SKILL.md
+++ b/skills/functional-ts/SKILL.md
@@ -48,7 +48,21 @@ type TaxiRequest = {
 
 ### Companion Objectパターン
 
-型定義と関連する関数を同名のオブジェクトにまとめる。
+型定義と関連する関数を同名のオブジェクトにまとめる。Branded Types の Zod スキーマは、スタンドアロンの export ではなく companion object の `schema` プロパティとして公開する。
+
+```typescript
+// ❌ スキーマを単独 export — 実装詳細の漏洩
+export const ItemIdSchema = z.string().regex(/^item-\d+$/).brand<"ItemId">();
+
+// ✅ companion object が schema を所有する
+const ItemIdSchema = z.string().regex(/^item-\d+$/).brand<"ItemId">();
+export type ItemId = z.infer<typeof ItemIdSchema>;
+
+export const ItemId = {
+  schema: ItemIdSchema,
+  parse: (raw: string) => ItemIdSchema.safeParse(raw),
+} as const;
+```
 
 ```typescript
 type TaxiRequest = Waiting | EnRoute | InTrip | Completed | Cancelled;
@@ -114,19 +128,50 @@ type TaskRepository = {
 
 構造的部分型により `string` 同士は互換になる。意味の異なるIDや値にはBranded Typeを適用する。
 
+Zodを使っている場合は `z.brand()` で定義する。スキーマの出力型が自動的にブランド付きになるため、`as` キャストが不要になる。
+
+```typescript
+import { z } from "zod";
+
+const UserIdSchema = z.string().uuid().brand<"UserId">();
+type UserId = z.infer<typeof UserIdSchema>;
+
+const ProductIdSchema = z.string().uuid().brand<"ProductId">();
+type ProductId = z.infer<typeof ProductIdSchema>;
+
+// safeParse().data は既にブランド付き — as 不要
+```
+
+Zodを使わないプロジェクトでは `unique symbol` パターンを使う。
+
 ```typescript
 declare const UserIdBrand: unique symbol;
 type UserId = string & { readonly [UserIdBrand]: never };
 
 declare const ProductIdBrand: unique symbol;
 type ProductId = string & { readonly [ProductIdBrand]: never };
-
-// UserId と ProductId は構造的に非互換になる
 ```
 
 ### `Readonly<>` で不変性を保証する
 
 ドメインオブジェクトは `Readonly<>` で定義し、プロパティの再代入を防ぐ。状態変更は新しいオブジェクトの生成で表現する。
+
+### ファイル構成: 1概念1ファイル
+
+各ドメイン概念（型 + companion object）は専用のファイルに配置する。`types.ts` や `models.ts` のような catch-all ファイルは禁止。型と振る舞いが分離し、循環依存の原因になる。
+
+```
+// ❌ types.ts に型を集約、companion は別ファイル
+// types.ts — ItemId, ItemType, Status, Priority, Item, Config, ...
+// item-id.ts — ItemId の companion object（types.ts から型を import）
+
+// ✅ 概念ごとにファイルを分割
+// item-id.ts — type ItemId + const ItemId (companion)
+// item-type.ts — type ItemType + const ItemType (companion)
+// status.ts — type Status + const Status (companion)
+```
+
+barrel file（`index.ts`）は re-export のみに使い、型や関数を直接定義しない。
 
 ## 2. 関数による状態遷移
 

--- a/skills/functional-ts/boundary-defense.md
+++ b/skills/functional-ts/boundary-defense.md
@@ -57,11 +57,25 @@ const user = data as User;
 const user = UserSchema.parse(data);
 ```
 
-唯一の例外は Branded Types の生成関数内。
+Branded Types についても `z.brand()` を使えば `as` は不要になる。
+
+```typescript
+// ❌ 手動ブランド + as キャスト
+type ItemId = string & { readonly __brand: unique symbol };
+const ItemIdSchema = z.string().regex(/^item-\d+$/);
+const parse = (raw: string): ItemId => ItemIdSchema.parse(raw) as ItemId;
+
+// ✅ z.brand() — as 不要
+const ItemIdSchema = z.string().regex(/^item-\d+$/).brand<"ItemId">();
+type ItemId = z.infer<typeof ItemIdSchema>;
+const parse = (raw: string): ItemId => ItemIdSchema.parse(raw); // 既に ItemId 型
+```
+
+Zodを使わないプロジェクトでは、Branded Types の生成関数内に限り `as` を許容する。
 
 ```typescript
 const UserId = {
-  of: (value: string): UserId => value as UserId, // ここだけ許容
+  of: (value: string): UserId => value as UserId, // Zod未使用時のみ許容
 };
 ```
 

--- a/skills/functional-ts/examples/taxi-request.ts
+++ b/skills/functional-ts/examples/taxi-request.ts
@@ -5,16 +5,35 @@
  * 無効な遷移はコンパイルエラーで検出される。
  */
 
-// --- Branded Types ---
+// --- Branded Types (z.brand) ---
 
-declare const PassengerIdBrand: unique symbol;
-type PassengerId = string & { readonly [PassengerIdBrand]: never };
+import { z } from "zod";
 
-declare const DriverIdBrand: unique symbol;
-type DriverId = string & { readonly [DriverIdBrand]: never };
+const PassengerIdSchema = z.string().uuid().brand<"PassengerId">();
+type PassengerId = z.infer<typeof PassengerIdSchema>;
 
-declare const RequestIdBrand: unique symbol;
-type RequestId = string & { readonly [RequestIdBrand]: never };
+const DriverIdSchema = z.string().uuid().brand<"DriverId">();
+type DriverId = z.infer<typeof DriverIdSchema>;
+
+const RequestIdSchema = z.string().uuid().brand<"RequestId">();
+type RequestId = z.infer<typeof RequestIdSchema>;
+
+// --- Branded Type Companion Objects ---
+
+const PassengerId = {
+  schema: PassengerIdSchema,
+  parse: (raw: string) => PassengerIdSchema.safeParse(raw),
+} as const;
+
+const DriverId = {
+  schema: DriverIdSchema,
+  parse: (raw: string) => DriverIdSchema.safeParse(raw),
+} as const;
+
+const RequestId = {
+  schema: RequestIdSchema,
+  parse: (raw: string) => RequestIdSchema.safeParse(raw),
+} as const;
 
 // --- State Types ---
 


### PR DESCRIPTION
## Summary

- Recommend z.brand() for Branded Type definitions, narrowing as cast exceptions to Zod-free projects only (Closes #5)
- Add pattern for exposing schema property on companion objects (Closes #6)
- Add one-concept-per-file principle, prohibiting catch-all files like types.ts (Closes #7)
- Update taxi-request.ts example to use z.brand() + companion object

## Test plan

- [ ] Verify SKILL.md Branded Types section contains z.brand() recommendation with examples
- [ ] Verify boundary-defense.md as ban section contains z.brand() alternative
- [ ] Verify SKILL.md Companion Object section contains .schema property example
- [ ] Verify SKILL.md has file structure guideline added
- [ ] Verify taxi-request.ts is updated to z.brand() + companion object pattern

Generated with Claude Code

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
