### PR TITLE
refactor(skill): make SKILL.md a thin pointer, extract details into sub-files

### DIFF
--- a/skills/functional-ts-ja/SKILL.md
+++ b/skills/functional-ts-ja/SKILL.md
@@ -9,348 +9,52 @@ description: サーバーサイドTypeScriptでドメインモデル、ユース
 
 ## 1. 型によるドメインモデリング
 
-### Discriminated Unionで状態を表現する
+Discriminated Unionで状態を表現し、`kind` をdiscriminantとして統一する。`type`（`interface` ではなく）、Companion Object、Branded Types、`Readonly<>`、関数プロパティ記法、1概念1ファイル構成を使う。
 
-ドメインエンティティの状態はclassではなくDiscriminated Unionで定義する。各状態を個別の型として定義し、状態固有のプロパティを必須にする。
-
-```typescript
-// Good: 各状態が独立した型。状態固有のプロパティが必須
-type Waiting = Readonly<{
-  kind: "Waiting";
-  passengerId: PassengerId;
-}>;
-
-type EnRoute = Readonly<{
-  kind: "EnRoute";
-  passengerId: PassengerId;
-  driverId: DriverId;
-}>;
-
-type TaxiRequest = Waiting | EnRoute | InTrip | Completed | Cancelled;
-```
-
-```typescript
-// Bad: optional プロパティで全状態を1つの型に押し込む
-type TaxiRequest = {
-  state: string;
-  passengerId: string;
-  driverId?: string;    // どの状態で存在するか不明
-  startTime?: Date;     // null チェックが至る所で必要
-  endTime?: Date;
-};
-```
-
-**理由:** optional プロパティは「どの状態でどのプロパティが存在するか」をコンパイル時に保証できない。Discriminated Unionなら、switch文でkindを判別した時点で状態固有のプロパティに安全にアクセスできる。
-
-### discriminantは `kind` で統一する
-
-プロジェクト全体で `kind` をdiscriminantプロパティ名として統一する。`type`, `status`, `state` などが混在するとコードベースの一貫性が損なわれる。
-
-### Companion Objectパターン
-
-型定義と関連する関数を同名のオブジェクトにまとめる。Branded Types のバリデーションスキーマは、スタンドアロンの export ではなく companion object の `schema` プロパティとして公開する。
-
-```typescript
-// ❌ スキーマを単独 export — 実装詳細の漏洩
-export const ItemIdBrand = Symbol();
-export const ItemIdSchema = z.string().regex(/^item-\d+$/).brand<typeof ItemIdBrand>();
-
-// ✅ companion object が schema を所有する
-const ItemIdBrand = Symbol();
-const ItemIdSchema = z.string().regex(/^item-\d+$/).brand<typeof ItemIdBrand>();
-export type ItemId = z.infer<typeof ItemIdSchema>;
-
-export const ItemId = {
-  schema: ItemIdSchema,
-  parse: (raw: string) => ItemIdSchema.safeParse(raw),
-} as const;
-```
-
-```typescript
-type TaxiRequest = Waiting | EnRoute | InTrip | Completed | Cancelled;
-
-const TaxiRequest = {
-  assignDriver: (waiting: Waiting, driverId: DriverId): EnRoute => ({
-    kind: "EnRoute",
-    passengerId: waiting.passengerId,
-    driverId,
-  }),
-
-  startTrip: (enRoute: EnRoute, startTime: Date): InTrip => ({
-    kind: "InTrip",
-    passengerId: enRoute.passengerId,
-    driverId: enRoute.driverId,
-    startTime,
-  }),
-
-  isActive: (request: TaxiRequest): request is Waiting | EnRoute | InTrip =>
-    request.kind !== "Completed" && request.kind !== "Cancelled",
-} as const;
-```
-
-### `type` を使う（`interface` ではなく）
-
-ドメイン型は `type` で定義する。`interface` のdeclaration mergingは、別ファイルで同名のinterfaceを宣言するだけで型の形状が暗黙的に変わる危険がある。
-
-```typescript
-// Good
-type User = Readonly<{
-  id: UserId;
-  name: string;
-}>;
-
-// Bad: 別ファイルで interface User { hashedPassword?: string } と宣言されると
-// 気づかないうちに型が変わる
-interface User {
-  id: string;
-  name: string;
-}
-```
-
-### 関数プロパティ記法を使う（メソッド記法ではなく）
-
-型定義内の関数はメソッド記法ではなく関数プロパティ記法で書く。メソッド記法はパラメータ型がbivariantになり、型安全性が崩れる。
-
-```typescript
-// Good: 関数プロパティ記法 — パラメータはcontravariant
-type TaskRepository = {
-  save: (task: Task) => Promise<void>;
-  findById: (id: TaskId) => Promise<Task | undefined>;
-};
-
-// Bad: メソッド記法 — パラメータがbivariantになり、
-// save(task: DoingTask) のような狭い実装が型チェックを通過してしまう
-type TaskRepository = {
-  save(task: Task): Promise<void>;
-  findById(id: TaskId): Promise<Task | undefined>;
-};
-```
-
-### Branded Typesで意味を区別する
-
-構造的部分型により `string` 同士は互換になる。意味の異なるIDや値にはBranded Typeを適用する。
-
-**バリデーションライブラリの検出:** プロジェクトの `package.json` の `dependencies` / `devDependencies` を確認し、該当するライブラリのガイドに従う。いずれも見つからない場合はユーザーに確認する。
+**バリデーションライブラリの検出:** プロジェクトの `package.json` の `dependencies` / `devDependencies` を確認:
 
 - `zod` → [validation-libraries/zod.md](./validation-libraries/zod.md)
 - `valibot` → [validation-libraries/valibot.md](./validation-libraries/valibot.md)
 - `arktype` → [validation-libraries/arktype.md](./validation-libraries/arktype.md)
 
-バリデーションライブラリを使っている場合は、そのブランド機能で定義する。スキーマの出力型が自動的にブランド付きになるため、`as` キャストが不要になる。以下はZodの例:
-
-```typescript
-import { z } from "zod";
-
-export const UserIdBrand = Symbol();
-const UserIdSchema = z.string().uuid().brand<typeof UserIdBrand>();
-type UserId = z.infer<typeof UserIdSchema>;
-
-export const ProductIdBrand = Symbol();
-const ProductIdSchema = z.string().uuid().brand<typeof ProductIdBrand>();
-type ProductId = z.infer<typeof ProductIdSchema>;
-
-// safeParse().data は既にブランド付き — as 不要
-```
-
-バリデーションライブラリを使わないプロジェクトでは `unique symbol` パターンを使う。
-
-```typescript
-export const UserIdBrand = Symbol();
-type UserId = string & { readonly [typeof UserIdBrand]: never };
-
-export const ProductIdBrand = Symbol();
-type ProductId = string & { readonly [typeof ProductIdBrand]: never };
-```
-
-### `Readonly<>` で不変性を保証する
-
-ドメインオブジェクトは `Readonly<>` で定義し、プロパティの再代入を防ぐ。状態変更は新しいオブジェクトの生成で表現する。
-
-### ファイル構成: 1概念1ファイル
-
-各ドメイン概念（型 + companion object）は専用のファイルに配置する。`types.ts` や `models.ts` のような catch-all ファイルは禁止。型と振る舞いが分離し、循環依存の原因になる。
-
-```
-// ❌ types.ts に型を集約、companion は別ファイル
-// types.ts — ItemId, ItemType, Status, Priority, Item, Config, ...
-// item-id.ts — ItemId の companion object（types.ts から型を import）
-
-// ✅ 概念ごとにファイルを分割
-// item-id.ts — type ItemId + const ItemId (companion)
-// item-type.ts — type ItemType + const ItemType (companion)
-// status.ts — type Status + const Status (companion)
-```
-
-barrel file（`index.ts`）は re-export のみに使い、型や関数を直接定義しない。
+詳細: [domain-modeling.md](./domain-modeling.md)
 
 ## 2. 関数による状態遷移
 
-純粋関数で状態遷移を表現する。関数の引数型が有効な遷移元を制約し、戻り値型が遷移先を明示する。
+純粋関数で状態遷移を表現する。関数の引数型が有効な遷移元を制約し、戻り値型が遷移先を明示する。無効な遷移はコンパイルエラーになる。`assertNever` で網羅性をチェックする。
 
-```typescript
-// assignDriver は Waiting 状態からのみ呼べる
-const assignDriver = (waiting: Waiting, driverId: DriverId): EnRoute => ({
-  kind: "EnRoute",
-  passengerId: waiting.passengerId,
-  driverId,
-});
-```
-
-無効な遷移（例: `assignDriver(completed, driverId)`）はコンパイルエラーになる。ランタイムチェックは不要。
-
-### 網羅性チェック
-
-switch文では `assertNever` を使い、すべてのケースを処理していることをコンパイル時に保証する。新しい状態が追加されたとき、未処理の箇所がコンパイルエラーで検出される。
-
-```typescript
-const assertNever = (x: never): never => {
-  throw new Error(`Unexpected value: ${JSON.stringify(x)}`);
-};
-
-const describe = (request: TaxiRequest): string => {
-  switch (request.kind) {
-    case "Waiting": return "Waiting for driver";
-    case "EnRoute": return `Driver ${request.driverId} en route`;
-    case "InTrip": return "In trip";
-    case "Completed": return "Completed";
-    case "Cancelled": return "Cancelled";
-    default: return assertNever(request);
-  }
-};
-```
+詳細: [state-modeling.md](./state-modeling.md)
 
 ## 3. エラーハンドリング — Railway Oriented Programming
 
-例外をスローせず、Result型でエラーを値として扱う。
+例外をスローせず、Result型でエラーを値として扱う。エラー型はDiscriminated Unionで定義し、呼び出し元が網羅的にハンドルできるようにする。
 
-**ライブラリの検出:** プロジェクトの `package.json` の `dependencies` / `devDependencies` を確認し、該当するライブラリのガイドに従う。いずれも見つからない場合はユーザーに確認する。
+**ライブラリの検出:** プロジェクトの `package.json` の `dependencies` / `devDependencies` を確認:
 
 - `neverthrow` → [result-libraries/neverthrow.md](./result-libraries/neverthrow.md)
 - `byethrow` → [result-libraries/byethrow.md](./result-libraries/byethrow.md)
 - `fp-ts` → [result-libraries/fp-ts.md](./result-libraries/fp-ts.md)
 - `option-t` → [result-libraries/option-t.md](./result-libraries/option-t.md)
 
-エラー型はDiscriminated Unionで定義し、呼び出し元が網羅的にハンドルできるようにする。
-
-```typescript
-type AssignError =
-  | Readonly<{ kind: "DriverNotAvailable"; driverId: DriverId }>
-  | Readonly<{ kind: "RequestAlreadyAssigned" }>;
-```
-
-成功・失敗を型で表現し、チェーンで処理を合成する。各ライブラリのAPIについては上記のガイドを参照。
-
 詳細: [error-handling.md](./error-handling.md)
 
 ## 4. 境界の防御
 
-外部入力（APIリクエスト、DB結果、ファイル読み込み）はバリデーションライブラリのスキーマでランタイムバリデーションする。ドメイン層内部では型を信頼し、過剰な防御的バリデーションをしない。バリデーションライブラリ固有の構文は、Branded Typesセクションでリンクした[バリデーションライブラリガイド](./validation-libraries/)を参照。
-
-```typescript
-import { z } from "zod";
-
-const CreateRequestSchema = z.object({
-  passengerId: z.string().uuid().transform(PassengerId.of),
-});
-
-// API handler
-const handler = (req: Request) => {
-  const result = CreateRequestSchema.safeParse(req.body);
-  if (!result.success) return badRequest(result.error);
-  // result.data は型安全。以降 as は不要
-};
-```
-
-### 型アサーション（`as`）を使わない
-
-`as` は型チェックをバイパスし、ランタイムエラーの原因になる。外部データにはスキーマパース、内部データは型推論を信頼する。
-
-### PIIの防御
-
-個人情報を含むフィールドには `Sensitive<T>` ラッパーを適用し、`JSON.stringify` や `console.log` で自動的にマスクする。
-
-```typescript
-type Sensitive<T> = Readonly<{
-  unwrap: () => T;
-  toJSON: () => string;
-  toString: () => string;
-}>;
-
-const Sensitive = {
-  of: <T>(value: T): Sensitive<T> => ({
-    unwrap: () => value,
-    toJSON: () => "[REDACTED]",
-    toString: () => "[REDACTED]",
-    [Symbol.for("nodejs.util.inspect.custom")]: () => "[REDACTED]",
-  }),
-} as const;
-```
-
-バリデーションスキーマで自動ラップする。以下はZodの例。ValibotとArkTypeの等価な構文は[バリデーションライブラリガイド](./validation-libraries/)を参照。
-
-```typescript
-const sensitiveString = z.string().transform(Sensitive.of);
-
-const PatientSchema = z.object({
-  name: sensitiveString,
-  email: sensitiveString,
-  role: z.string(), // PIIではないのでそのまま
-});
-```
+外部入力（APIリクエスト、DB結果、ファイル読み込み）はバリデーションライブラリのスキーマでランタイムバリデーションする。ドメイン層内部では型を信頼する。型アサーション（`as`）は使わない。PIIフィールドには `Sensitive<T>` ラッパーを適用する。
 
 詳細: [boundary-defense.md](./boundary-defense.md)
 
 ## 5. 宣言的なスタイル
 
-### 配列操作
+配列の変換は `filter` / `map` / `reduce` でCompanion Objectの述語関数を使って宣言的に書く。ドメインイベントは不変レコードとしてモデリングする。
 
-配列の変換は `filter` / `map` / `reduce` で宣言的に書く。述語関数はCompanion Objectに定義する。
-
-```typescript
-type Task = ActiveTask | CompletedTask;
-
-const Task = {
-  isActive: (task: Task): task is ActiveTask => task.kind === "Active",
-} as const;
-
-// 宣言的: 「何をしたいか」が明確
-const activeTasks = tasks.filter(Task.isActive);
-
-// 命令的: ループの中身を読まないと意図がわからない
-const activeTasks: ActiveTask[] = [];
-for (const task of tasks) {
-  if (task.kind === "Active") activeTasks.push(task);
-}
-```
-
-### ドメインイベント
-
-状態変更に伴うドメインイベントは不変レコードとして生成し、リポジトリとは分離して記録する。
-
-```typescript
-type DomainEvent = Readonly<{
-  eventId: string;
-  eventAt: Date;
-  eventName: string;
-  payload: unknown;
-  aggregateId: string;
-}>;
-```
-
-詳細: [state-modeling.md](./state-modeling.md)
+詳細: [declarative-style.md](./declarative-style.md)
 
 ## 6. テストデータ
 
-テストのダミーデータは `as const satisfies Type` で型安全に定義する。discriminantのリテラル型が保持され、wideningを防ぐ。
+テストデータは `as const satisfies Type` で定義し、discriminantのリテラル型を保持しwideningを防ぐ。
 
-```typescript
-const waitingRequest = {
-  kind: "Waiting",
-  passengerId: "passenger-1" as PassengerId,
-} as const satisfies Waiting;
-
-// waitingRequest.kind は "Waiting" リテラル型（string ではない）
-```
+詳細: [test-data.md](./test-data.md)
 
 ## 原則の適用について
 

--- a/skills/functional-ts-ja/declarative-style.md
+++ b/skills/functional-ts-ja/declarative-style.md
@@ -1,0 +1,38 @@
+# 宣言的なスタイル 詳細ガイド
+
+## 配列操作
+
+配列の変換は `filter` / `map` / `reduce` で宣言的に書く。述語関数はCompanion Objectに定義する。
+
+```typescript
+type Task = ActiveTask | CompletedTask;
+
+const Task = {
+  isActive: (task: Task): task is ActiveTask => task.kind === "Active",
+} as const;
+
+// 宣言的: 「何をしたいか」が明確
+const activeTasks = tasks.filter(Task.isActive);
+
+// 命令的: ループの中身を読まないと意図がわからない
+const activeTasks: ActiveTask[] = [];
+for (const task of tasks) {
+  if (task.kind === "Active") activeTasks.push(task);
+}
+```
+
+## ドメインイベント
+
+状態変更に伴うドメインイベントは不変レコードとして生成し、リポジトリとは分離して記録する。
+
+```typescript
+type DomainEvent = Readonly<{
+  eventId: string;
+  eventAt: Date;
+  eventName: string;
+  payload: unknown;
+  aggregateId: string;
+}>;
+```
+
+ドメインイベントの詳細設計（イベント生成の責務、ユースケースとの統合）は [state-modeling.md](./state-modeling.md) を参照。

--- a/skills/functional-ts-ja/domain-modeling.md
+++ b/skills/functional-ts-ja/domain-modeling.md
@@ -1,0 +1,175 @@
+# 型によるドメインモデリング 詳細ガイド
+
+## Discriminated Unionで状態を表現する
+
+ドメインエンティティの状態はclassではなくDiscriminated Unionで定義する。各状態を個別の型として定義し、状態固有のプロパティを必須にする。
+
+```typescript
+// Good: 各状態が独立した型。状態固有のプロパティが必須
+type Waiting = Readonly<{
+  kind: "Waiting";
+  passengerId: PassengerId;
+}>;
+
+type EnRoute = Readonly<{
+  kind: "EnRoute";
+  passengerId: PassengerId;
+  driverId: DriverId;
+}>;
+
+type TaxiRequest = Waiting | EnRoute | InTrip | Completed | Cancelled;
+```
+
+```typescript
+// Bad: optional プロパティで全状態を1つの型に押し込む
+type TaxiRequest = {
+  state: string;
+  passengerId: string;
+  driverId?: string;    // どの状態で存在するか不明
+  startTime?: Date;     // null チェックが至る所で必要
+  endTime?: Date;
+};
+```
+
+**理由:** optional プロパティは「どの状態でどのプロパティが存在するか」をコンパイル時に保証できない。Discriminated Unionなら、switch文でkindを判別した時点で状態固有のプロパティに安全にアクセスできる。
+
+## discriminantは `kind` で統一する
+
+プロジェクト全体で `kind` をdiscriminantプロパティ名として統一する。`type`, `status`, `state` などが混在するとコードベースの一貫性が損なわれる。
+
+## Companion Objectパターン
+
+型定義と関連する関数を同名のオブジェクトにまとめる。Branded Types のバリデーションスキーマは、スタンドアロンの export ではなく companion object の `schema` プロパティとして公開する。
+
+```typescript
+// ❌ スキーマを単独 export — 実装詳細の漏洩
+export const ItemIdBrand = Symbol();
+export const ItemIdSchema = z.string().regex(/^item-\d+$/).brand<typeof ItemIdBrand>();
+
+// ✅ companion object が schema を所有する
+const ItemIdBrand = Symbol();
+const ItemIdSchema = z.string().regex(/^item-\d+$/).brand<typeof ItemIdBrand>();
+export type ItemId = z.infer<typeof ItemIdSchema>;
+
+export const ItemId = {
+  schema: ItemIdSchema,
+  parse: (raw: string) => ItemIdSchema.safeParse(raw),
+} as const;
+```
+
+```typescript
+type TaxiRequest = Waiting | EnRoute | InTrip | Completed | Cancelled;
+
+const TaxiRequest = {
+  assignDriver: (waiting: Waiting, driverId: DriverId): EnRoute => ({
+    kind: "EnRoute",
+    passengerId: waiting.passengerId,
+    driverId,
+  }),
+
+  startTrip: (enRoute: EnRoute, startTime: Date): InTrip => ({
+    kind: "InTrip",
+    passengerId: enRoute.passengerId,
+    driverId: enRoute.driverId,
+    startTime,
+  }),
+
+  isActive: (request: TaxiRequest): request is Waiting | EnRoute | InTrip =>
+    request.kind !== "Completed" && request.kind !== "Cancelled",
+} as const;
+```
+
+## `type` を使う（`interface` ではなく）
+
+ドメイン型は `type` で定義する。`interface` のdeclaration mergingは、別ファイルで同名のinterfaceを宣言するだけで型の形状が暗黙的に変わる危険がある。
+
+```typescript
+// Good
+type User = Readonly<{
+  id: UserId;
+  name: string;
+}>;
+
+// Bad: 別ファイルで interface User { hashedPassword?: string } と宣言されると
+// 気づかないうちに型が変わる
+interface User {
+  id: string;
+  name: string;
+}
+```
+
+## 関数プロパティ記法を使う（メソッド記法ではなく）
+
+型定義内の関数はメソッド記法ではなく関数プロパティ記法で書く。メソッド記法はパラメータ型がbivariantになり、型安全性が崩れる。
+
+```typescript
+// Good: 関数プロパティ記法 — パラメータはcontravariant
+type TaskRepository = {
+  save: (task: Task) => Promise<void>;
+  findById: (id: TaskId) => Promise<Task | undefined>;
+};
+
+// Bad: メソッド記法 — パラメータがbivariantになり、
+// save(task: DoingTask) のような狭い実装が型チェックを通過してしまう
+type TaskRepository = {
+  save(task: Task): Promise<void>;
+  findById(id: TaskId): Promise<Task | undefined>;
+};
+```
+
+## Branded Typesで意味を区別する
+
+構造的部分型により `string` 同士は互換になる。意味の異なるIDや値にはBranded Typeを適用する。
+
+**バリデーションライブラリの検出:** プロジェクトの `package.json` の `dependencies` / `devDependencies` を確認し、該当するライブラリのガイドに従う。いずれも見つからない場合はユーザーに確認する。
+
+- `zod` → [validation-libraries/zod.md](./validation-libraries/zod.md)
+- `valibot` → [validation-libraries/valibot.md](./validation-libraries/valibot.md)
+- `arktype` → [validation-libraries/arktype.md](./validation-libraries/arktype.md)
+
+バリデーションライブラリを使っている場合は、そのブランド機能で定義する。スキーマの出力型が自動的にブランド付きになるため、`as` キャストが不要になる。以下はZodの例:
+
+```typescript
+import { z } from "zod";
+
+export const UserIdBrand = Symbol();
+const UserIdSchema = z.string().uuid().brand<typeof UserIdBrand>();
+type UserId = z.infer<typeof UserIdSchema>;
+
+export const ProductIdBrand = Symbol();
+const ProductIdSchema = z.string().uuid().brand<typeof ProductIdBrand>();
+type ProductId = z.infer<typeof ProductIdSchema>;
+
+// safeParse().data は既にブランド付き — as 不要
+```
+
+バリデーションライブラリを使わないプロジェクトでは `unique symbol` パターンを使う。
+
+```typescript
+export const UserIdBrand = Symbol();
+type UserId = string & { readonly [typeof UserIdBrand]: never };
+
+export const ProductIdBrand = Symbol();
+type ProductId = string & { readonly [typeof ProductIdBrand]: never };
+```
+
+## `Readonly<>` で不変性を保証する
+
+ドメインオブジェクトは `Readonly<>` で定義し、プロパティの再代入を防ぐ。状態変更は新しいオブジェクトの生成で表現する。
+
+## ファイル構成: 1概念1ファイル
+
+各ドメイン概念（型 + companion object）は専用のファイルに配置する。`types.ts` や `models.ts` のような catch-all ファイルは禁止。型と振る舞いが分離し、循環依存の原因になる。
+
+```
+// ❌ types.ts に型を集約、companion は別ファイル
+// types.ts — ItemId, ItemType, Status, Priority, Item, Config, ...
+// item-id.ts — ItemId の companion object（types.ts から型を import）
+
+// ✅ 概念ごとにファイルを分割
+// item-id.ts — type ItemId + const ItemId (companion)
+// item-type.ts — type ItemType + const ItemType (companion)
+// status.ts — type Status + const Status (companion)
+```
+
+barrel file（`index.ts`）は re-export のみに使い、型や関数を直接定義しない。

--- a/skills/functional-ts-ja/test-data.md
+++ b/skills/functional-ts-ja/test-data.md
@@ -1,0 +1,32 @@
+# テストデータガイド
+
+## `as const satisfies` で型安全なテストフィクスチャを定義する
+
+テストのダミーデータは `as const satisfies Type` で型安全に定義する。discriminantのリテラル型が保持され、wideningを防ぐ。
+
+```typescript
+const waitingRequest = {
+  kind: "Waiting",
+  passengerId: "passenger-1" as PassengerId,
+} as const satisfies Waiting;
+
+// waitingRequest.kind は "Waiting" リテラル型（string ではない）
+```
+
+### なぜ `as const` だけでは不十分か
+
+`as const` だけではリテラル型は保持されるが、オブジェクトが期待する型と一致しているか検証されない。`satisfies Type` を追加することで、コンパイル時に型互換性が保証され、かつリテラル型も維持される。
+
+```typescript
+// ❌ 型チェックなし — タイポが検出されない
+const bad = {
+  kind: "Waitng", // タイポが見逃される
+  passengerId: "passenger-1" as PassengerId,
+} as const;
+
+// ✅ 型チェックあり + リテラル型保持
+const good = {
+  kind: "Waiting",
+  passengerId: "passenger-1" as PassengerId,
+} as const satisfies Waiting;
+```

--- a/skills/functional-ts/SKILL.md
+++ b/skills/functional-ts/SKILL.md
@@ -9,348 +9,52 @@ Principles for writing domain models in server-side TypeScript. Instead of class
 
 ## 1. Type-Driven Domain Modeling
 
-### Represent State with Discriminated Unions
+Represent states with discriminated unions using `kind` as the unified discriminant. Use `type` (not `interface`), companion objects, branded types, `Readonly<>`, function property notation, and one-concept-per-file structure.
 
-Define domain entity states using Discriminated Unions instead of classes. Define each state as its own type and make state-specific properties required.
-
-```typescript
-// Good: Each state is an independent type. State-specific properties are required
-type Waiting = Readonly<{
-  kind: "Waiting";
-  passengerId: PassengerId;
-}>;
-
-type EnRoute = Readonly<{
-  kind: "EnRoute";
-  passengerId: PassengerId;
-  driverId: DriverId;
-}>;
-
-type TaxiRequest = Waiting | EnRoute | InTrip | Completed | Cancelled;
-```
-
-```typescript
-// Bad: Cramming all states into one type with optional properties
-type TaxiRequest = {
-  state: string;
-  passengerId: string;
-  driverId?: string;    // unclear which state this exists in
-  startTime?: Date;     // null checks required everywhere
-  endTime?: Date;
-};
-```
-
-**Rationale:** Optional properties cannot guarantee at compile time which properties exist in which state. With Discriminated Unions, once you narrow on `kind` in a switch statement, you can safely access state-specific properties.
-
-### Use `kind` as the unified discriminant
-
-Use `kind` as the discriminant property name throughout the entire project. Mixing `type`, `status`, `state`, etc. undermines codebase consistency.
-
-### Companion Object Pattern
-
-Group a type definition and its related functions under an object of the same name. Branded Type validation schemas should be exposed as a `schema` property on the companion object, not as standalone exports.
-
-```typescript
-// ❌ Standalone schema export — leaks implementation details
-export const ItemIdBrand = Symbol();
-export const ItemIdSchema = z.string().regex(/^item-\d+$/).brand<typeof ItemIdBrand>();
-
-// ✅ Companion object owns the schema
-const ItemIdBrand = Symbol();
-const ItemIdSchema = z.string().regex(/^item-\d+$/).brand<typeof ItemIdBrand>();
-export type ItemId = z.infer<typeof ItemIdSchema>;
-
-export const ItemId = {
-  schema: ItemIdSchema,
-  parse: (raw: string) => ItemIdSchema.safeParse(raw),
-} as const;
-```
-
-```typescript
-type TaxiRequest = Waiting | EnRoute | InTrip | Completed | Cancelled;
-
-const TaxiRequest = {
-  assignDriver: (waiting: Waiting, driverId: DriverId): EnRoute => ({
-    kind: "EnRoute",
-    passengerId: waiting.passengerId,
-    driverId,
-  }),
-
-  startTrip: (enRoute: EnRoute, startTime: Date): InTrip => ({
-    kind: "InTrip",
-    passengerId: enRoute.passengerId,
-    driverId: enRoute.driverId,
-    startTime,
-  }),
-
-  isActive: (request: TaxiRequest): request is Waiting | EnRoute | InTrip =>
-    request.kind !== "Completed" && request.kind !== "Cancelled",
-} as const;
-```
-
-### Use `type` (not `interface`)
-
-Define domain types with `type`. The declaration merging of `interface` poses a risk: declaring an interface with the same name in another file silently changes the type's shape.
-
-```typescript
-// Good
-type User = Readonly<{
-  id: UserId;
-  name: string;
-}>;
-
-// Bad: if another file declares `interface User { hashedPassword?: string }`,
-// the type changes without you noticing
-interface User {
-  id: string;
-  name: string;
-}
-```
-
-### Use function property notation (not method notation)
-
-Write functions inside type definitions using function property notation, not method notation. Method notation makes parameter types bivariant, breaking type safety.
-
-```typescript
-// Good: function property notation — parameters are contravariant
-type TaskRepository = {
-  save: (task: Task) => Promise<void>;
-  findById: (id: TaskId) => Promise<Task | undefined>;
-};
-
-// Bad: method notation — parameters become bivariant,
-// allowing a narrower implementation like save(task: DoingTask) to pass type checks
-type TaskRepository = {
-  save(task: Task): Promise<void>;
-  findById(id: TaskId): Promise<Task | undefined>;
-};
-```
-
-### Distinguish meaning with Branded Types
-
-Due to structural subtyping, two `string` values are compatible. Apply Branded Types to IDs and values with different semantic meanings.
-
-**Validation library detection:** Check `dependencies` / `devDependencies` in the project's `package.json` and follow the guide for the matching library. If none are found, ask the user.
+**Validation library detection:** Check `dependencies` / `devDependencies` in the project's `package.json` for branded type syntax:
 
 - `zod` → [validation-libraries/zod.md](./validation-libraries/zod.md)
 - `valibot` → [validation-libraries/valibot.md](./validation-libraries/valibot.md)
 - `arktype` → [validation-libraries/arktype.md](./validation-libraries/arktype.md)
 
-When using a validation library, define brands with its brand feature. The schema output type becomes automatically branded, eliminating the need for `as` casts. The following example uses Zod:
-
-```typescript
-import { z } from "zod";
-
-export const UserIdBrand = Symbol();
-const UserIdSchema = z.string().uuid().brand<typeof UserIdBrand>();
-type UserId = z.infer<typeof UserIdSchema>;
-
-export const ProductIdBrand = Symbol();
-const ProductIdSchema = z.string().uuid().brand<typeof ProductIdBrand>();
-type ProductId = z.infer<typeof ProductIdSchema>;
-
-// safeParse().data is already branded — no `as` cast needed
-```
-
-For projects not using a validation library, use the `unique symbol` pattern.
-
-```typescript
-export const UserIdBrand = Symbol();
-type UserId = string & { readonly [typeof UserIdBrand]: never };
-
-export const ProductIdBrand = Symbol();
-type ProductId = string & { readonly [typeof ProductIdBrand]: never };
-```
-
-### Ensure immutability with `Readonly<>`
-
-Define domain objects with `Readonly<>` to prevent property reassignment. Express state changes by creating new objects.
-
-### File structure: one concept per file
-
-Place each domain concept (type + companion object) in its own dedicated file. Catch-all files like `types.ts` or `models.ts` are prohibited — they separate types from behavior and cause circular dependencies.
-
-```
-// ❌ Types aggregated in types.ts, companions in separate files
-// types.ts — ItemId, ItemType, Status, Priority, Item, Config, ...
-// item-id.ts — ItemId companion object (imports type from types.ts)
-
-// ✅ Split files per concept
-// item-id.ts — type ItemId + const ItemId (companion)
-// item-type.ts — type ItemType + const ItemType (companion)
-// status.ts — type Status + const Status (companion)
-```
-
-Barrel files (`index.ts`) are for re-exports only; do not define types or functions directly in them.
+Details: [domain-modeling.md](./domain-modeling.md)
 
 ## 2. State Transitions via Functions
 
-Express state transitions with pure functions. The argument type constrains valid source states, and the return type makes the target state explicit.
+Express state transitions with pure functions. The argument type constrains valid source states, and the return type makes the target state explicit. Invalid transitions become compile errors. Use `assertNever` for exhaustiveness checking.
 
-```typescript
-// assignDriver can only be called from the Waiting state
-const assignDriver = (waiting: Waiting, driverId: DriverId): EnRoute => ({
-  kind: "EnRoute",
-  passengerId: waiting.passengerId,
-  driverId,
-});
-```
-
-Invalid transitions (e.g., `assignDriver(completed, driverId)`) become compile errors. No runtime checks needed.
-
-### Exhaustiveness Checking
-
-Use `assertNever` in switch statements to guarantee at compile time that all cases are handled. When a new state is added, unhandled locations are caught as compile errors.
-
-```typescript
-const assertNever = (x: never): never => {
-  throw new Error(`Unexpected value: ${JSON.stringify(x)}`);
-};
-
-const describe = (request: TaxiRequest): string => {
-  switch (request.kind) {
-    case "Waiting": return "Waiting for driver";
-    case "EnRoute": return `Driver ${request.driverId} en route`;
-    case "InTrip": return "In trip";
-    case "Completed": return "Completed";
-    case "Cancelled": return "Cancelled";
-    default: return assertNever(request);
-  }
-};
-```
+Details: [state-modeling.md](./state-modeling.md)
 
 ## 3. Error Handling — Railway Oriented Programming
 
-Do not throw exceptions; treat errors as values using the Result type.
+Do not throw exceptions; treat errors as values using the Result type. Define error types as discriminated unions so callers can handle them exhaustively.
 
-**Library detection:** Check `dependencies` / `devDependencies` in the project's `package.json` and follow the guide for the matching library. If none are found, ask the user.
+**Library detection:** Check `dependencies` / `devDependencies` in the project's `package.json`:
 
 - `neverthrow` → [result-libraries/neverthrow.md](./result-libraries/neverthrow.md)
 - `byethrow` → [result-libraries/byethrow.md](./result-libraries/byethrow.md)
 - `fp-ts` → [result-libraries/fp-ts.md](./result-libraries/fp-ts.md)
 - `option-t` → [result-libraries/option-t.md](./result-libraries/option-t.md)
 
-Define error types as Discriminated Unions so callers can handle them exhaustively.
-
-```typescript
-type AssignError =
-  | Readonly<{ kind: "DriverNotAvailable"; driverId: DriverId }>
-  | Readonly<{ kind: "RequestAlreadyAssigned" }>;
-```
-
-Express success and failure with types and compose processing with chains. See the library-specific guides above for each library's API.
-
 Details: [error-handling.md](./error-handling.md)
 
 ## 4. Boundary Defense
 
-Validate external inputs (API requests, DB results, file reads) with validation library schemas at runtime. Trust types inside the domain layer and avoid excessive defensive validation. For validation library-specific syntax, see the [validation library guides](./validation-libraries/) linked in the Branded Types section above.
-
-```typescript
-import { z } from "zod";
-
-const CreateRequestSchema = z.object({
-  passengerId: z.string().uuid().transform(PassengerId.of),
-});
-
-// API handler
-const handler = (req: Request) => {
-  const result = CreateRequestSchema.safeParse(req.body);
-  if (!result.success) return badRequest(result.error);
-  // result.data is type-safe. No `as` cast needed from here on
-};
-```
-
-### Do not use type assertions (`as`)
-
-`as` bypasses type checks and causes runtime errors. Use schema parsing for external data; trust type inference for internal data.
-
-### PII Protection
-
-Apply a `Sensitive<T>` wrapper to fields containing personal information to automatically mask them in `JSON.stringify` and `console.log`.
-
-```typescript
-type Sensitive<T> = Readonly<{
-  unwrap: () => T;
-  toJSON: () => string;
-  toString: () => string;
-}>;
-
-const Sensitive = {
-  of: <T>(value: T): Sensitive<T> => ({
-    unwrap: () => value,
-    toJSON: () => "[REDACTED]",
-    toString: () => "[REDACTED]",
-    [Symbol.for("nodejs.util.inspect.custom")]: () => "[REDACTED]",
-  }),
-} as const;
-```
-
-Auto-wrap using a validation schema. The following example uses Zod; see the [validation library guides](./validation-libraries/) for Valibot and ArkType equivalents.
-
-```typescript
-const sensitiveString = z.string().transform(Sensitive.of);
-
-const PatientSchema = z.object({
-  name: sensitiveString,
-  email: sensitiveString,
-  role: z.string(), // not PII, so left as-is
-});
-```
+Validate external inputs (API requests, DB results, file reads) with validation library schemas at runtime. Trust types inside the domain layer. Do not use type assertions (`as`). Apply `Sensitive<T>` wrapper to PII fields.
 
 Details: [boundary-defense.md](./boundary-defense.md)
 
 ## 5. Declarative Style
 
-### Array Operations
+Write array transformations declaratively using `filter` / `map` / `reduce` with companion object predicates. Model domain events as immutable records.
 
-Write array transformations declaratively using `filter` / `map` / `reduce`. Define predicate functions in the Companion Object.
-
-```typescript
-type Task = ActiveTask | CompletedTask;
-
-const Task = {
-  isActive: (task: Task): task is ActiveTask => task.kind === "Active",
-} as const;
-
-// Declarative: intent is clear
-const activeTasks = tasks.filter(Task.isActive);
-
-// Imperative: you have to read the loop body to understand the intent
-const activeTasks: ActiveTask[] = [];
-for (const task of tasks) {
-  if (task.kind === "Active") activeTasks.push(task);
-}
-```
-
-### Domain Events
-
-Generate domain events that accompany state changes as immutable records, and record them separately from the repository.
-
-```typescript
-type DomainEvent = Readonly<{
-  eventId: string;
-  eventAt: Date;
-  eventName: string;
-  payload: unknown;
-  aggregateId: string;
-}>;
-```
-
-Details: [state-modeling.md](./state-modeling.md)
+Details: [declarative-style.md](./declarative-style.md)
 
 ## 6. Test Data
 
-Define dummy test data in a type-safe way using `as const satisfies Type`. This preserves discriminant literal types and prevents widening.
+Define test data with `as const satisfies Type` to preserve discriminant literal types and prevent widening.
 
-```typescript
-const waitingRequest = {
-  kind: "Waiting",
-  passengerId: "passenger-1" as PassengerId,
-} as const satisfies Waiting;
-
-// waitingRequest.kind is the "Waiting" literal type (not string)
-```
+Details: [test-data.md](./test-data.md)
 
 ## Applying These Principles
 

--- a/skills/functional-ts/declarative-style.md
+++ b/skills/functional-ts/declarative-style.md
@@ -1,0 +1,38 @@
+# Declarative Style Detailed Guide
+
+## Array Operations
+
+Write array transformations declaratively using `filter` / `map` / `reduce`. Define predicate functions in the Companion Object.
+
+```typescript
+type Task = ActiveTask | CompletedTask;
+
+const Task = {
+  isActive: (task: Task): task is ActiveTask => task.kind === "Active",
+} as const;
+
+// Declarative: intent is clear
+const activeTasks = tasks.filter(Task.isActive);
+
+// Imperative: you have to read the loop body to understand the intent
+const activeTasks: ActiveTask[] = [];
+for (const task of tasks) {
+  if (task.kind === "Active") activeTasks.push(task);
+}
+```
+
+## Domain Events
+
+Generate domain events that accompany state changes as immutable records, and record them separately from the repository.
+
+```typescript
+type DomainEvent = Readonly<{
+  eventId: string;
+  eventAt: Date;
+  eventName: string;
+  payload: unknown;
+  aggregateId: string;
+}>;
+```
+
+For detailed design of domain events (event generation responsibility, use case integration), see [state-modeling.md](./state-modeling.md).

--- a/skills/functional-ts/domain-modeling.md
+++ b/skills/functional-ts/domain-modeling.md
@@ -1,0 +1,175 @@
+# Type-Driven Domain Modeling Detailed Guide
+
+## Represent State with Discriminated Unions
+
+Define domain entity states using Discriminated Unions instead of classes. Define each state as its own type and make state-specific properties required.
+
+```typescript
+// Good: Each state is an independent type. State-specific properties are required
+type Waiting = Readonly<{
+  kind: "Waiting";
+  passengerId: PassengerId;
+}>;
+
+type EnRoute = Readonly<{
+  kind: "EnRoute";
+  passengerId: PassengerId;
+  driverId: DriverId;
+}>;
+
+type TaxiRequest = Waiting | EnRoute | InTrip | Completed | Cancelled;
+```
+
+```typescript
+// Bad: Cramming all states into one type with optional properties
+type TaxiRequest = {
+  state: string;
+  passengerId: string;
+  driverId?: string;    // unclear which state this exists in
+  startTime?: Date;     // null checks required everywhere
+  endTime?: Date;
+};
+```
+
+**Rationale:** Optional properties cannot guarantee at compile time which properties exist in which state. With Discriminated Unions, once you narrow on `kind` in a switch statement, you can safely access state-specific properties.
+
+## Use `kind` as the unified discriminant
+
+Use `kind` as the discriminant property name throughout the entire project. Mixing `type`, `status`, `state`, etc. undermines codebase consistency.
+
+## Companion Object Pattern
+
+Group a type definition and its related functions under an object of the same name. Branded Type validation schemas should be exposed as a `schema` property on the companion object, not as standalone exports.
+
+```typescript
+// ❌ Standalone schema export — leaks implementation details
+export const ItemIdBrand = Symbol();
+export const ItemIdSchema = z.string().regex(/^item-\d+$/).brand<typeof ItemIdBrand>();
+
+// ✅ Companion object owns the schema
+const ItemIdBrand = Symbol();
+const ItemIdSchema = z.string().regex(/^item-\d+$/).brand<typeof ItemIdBrand>();
+export type ItemId = z.infer<typeof ItemIdSchema>;
+
+export const ItemId = {
+  schema: ItemIdSchema,
+  parse: (raw: string) => ItemIdSchema.safeParse(raw),
+} as const;
+```
+
+```typescript
+type TaxiRequest = Waiting | EnRoute | InTrip | Completed | Cancelled;
+
+const TaxiRequest = {
+  assignDriver: (waiting: Waiting, driverId: DriverId): EnRoute => ({
+    kind: "EnRoute",
+    passengerId: waiting.passengerId,
+    driverId,
+  }),
+
+  startTrip: (enRoute: EnRoute, startTime: Date): InTrip => ({
+    kind: "InTrip",
+    passengerId: enRoute.passengerId,
+    driverId: enRoute.driverId,
+    startTime,
+  }),
+
+  isActive: (request: TaxiRequest): request is Waiting | EnRoute | InTrip =>
+    request.kind !== "Completed" && request.kind !== "Cancelled",
+} as const;
+```
+
+## Use `type` (not `interface`)
+
+Define domain types with `type`. The declaration merging of `interface` poses a risk: declaring an interface with the same name in another file silently changes the type's shape.
+
+```typescript
+// Good
+type User = Readonly<{
+  id: UserId;
+  name: string;
+}>;
+
+// Bad: if another file declares `interface User { hashedPassword?: string }`,
+// the type changes without you noticing
+interface User {
+  id: string;
+  name: string;
+}
+```
+
+## Use function property notation (not method notation)
+
+Write functions inside type definitions using function property notation, not method notation. Method notation makes parameter types bivariant, breaking type safety.
+
+```typescript
+// Good: function property notation — parameters are contravariant
+type TaskRepository = {
+  save: (task: Task) => Promise<void>;
+  findById: (id: TaskId) => Promise<Task | undefined>;
+};
+
+// Bad: method notation — parameters become bivariant,
+// allowing a narrower implementation like save(task: DoingTask) to pass type checks
+type TaskRepository = {
+  save(task: Task): Promise<void>;
+  findById(id: TaskId): Promise<Task | undefined>;
+};
+```
+
+## Distinguish meaning with Branded Types
+
+Due to structural subtyping, two `string` values are compatible. Apply Branded Types to IDs and values with different semantic meanings.
+
+**Validation library detection:** Check `dependencies` / `devDependencies` in the project's `package.json` and follow the guide for the matching library. If none are found, ask the user.
+
+- `zod` → [validation-libraries/zod.md](./validation-libraries/zod.md)
+- `valibot` → [validation-libraries/valibot.md](./validation-libraries/valibot.md)
+- `arktype` → [validation-libraries/arktype.md](./validation-libraries/arktype.md)
+
+When using a validation library, define brands with its brand feature. The schema output type becomes automatically branded, eliminating the need for `as` casts. The following example uses Zod:
+
+```typescript
+import { z } from "zod";
+
+export const UserIdBrand = Symbol();
+const UserIdSchema = z.string().uuid().brand<typeof UserIdBrand>();
+type UserId = z.infer<typeof UserIdSchema>;
+
+export const ProductIdBrand = Symbol();
+const ProductIdSchema = z.string().uuid().brand<typeof ProductIdBrand>();
+type ProductId = z.infer<typeof ProductIdSchema>;
+
+// safeParse().data is already branded — no `as` cast needed
+```
+
+For projects not using a validation library, use the `unique symbol` pattern.
+
+```typescript
+export const UserIdBrand = Symbol();
+type UserId = string & { readonly [typeof UserIdBrand]: never };
+
+export const ProductIdBrand = Symbol();
+type ProductId = string & { readonly [typeof ProductIdBrand]: never };
+```
+
+## Ensure immutability with `Readonly<>`
+
+Define domain objects with `Readonly<>` to prevent property reassignment. Express state changes by creating new objects.
+
+## File structure: one concept per file
+
+Place each domain concept (type + companion object) in its own dedicated file. Catch-all files like `types.ts` or `models.ts` are prohibited — they separate types from behavior and cause circular dependencies.
+
+```
+// ❌ Types aggregated in types.ts, companions in separate files
+// types.ts — ItemId, ItemType, Status, Priority, Item, Config, ...
+// item-id.ts — ItemId companion object (imports type from types.ts)
+
+// ✅ Split files per concept
+// item-id.ts — type ItemId + const ItemId (companion)
+// item-type.ts — type ItemType + const ItemType (companion)
+// status.ts — type Status + const Status (companion)
+```
+
+Barrel files (`index.ts`) are for re-exports only; do not define types or functions directly in them.

--- a/skills/functional-ts/test-data.md
+++ b/skills/functional-ts/test-data.md
@@ -1,0 +1,32 @@
+# Test Data Guide
+
+## Type-Safe Test Fixtures with `as const satisfies`
+
+Define dummy test data using `as const satisfies Type`. This preserves discriminant literal types and prevents widening.
+
+```typescript
+const waitingRequest = {
+  kind: "Waiting",
+  passengerId: "passenger-1" as PassengerId,
+} as const satisfies Waiting;
+
+// waitingRequest.kind is the "Waiting" literal type (not string)
+```
+
+### Why not just `as const`?
+
+`as const` alone preserves literal types but does not verify that the object matches the expected type. Adding `satisfies Type` ensures type compatibility at compile time while keeping the narrow literal type.
+
+```typescript
+// ❌ No type checking — typos go unnoticed
+const bad = {
+  kind: "Waitng", // typo not caught
+  passengerId: "passenger-1" as PassengerId,
+} as const;
+
+// ✅ Type-checked + literal types preserved
+const good = {
+  kind: "Waiting",
+  passengerId: "passenger-1" as PassengerId,
+} as const satisfies Waiting;
+```


### PR DESCRIPTION
## Why

SKILL.md (362 lines each for EN/JA) was fully loaded on skill invocation, consuming excessive context window. Agents should only read detailed sub-files on demand.

Considered `.claude/rules/` but ruled it out: not distributed via `npx skills add` and Claude Code-specific (incompatible with Copilot CLI, Gemini CLI, etc.).

## What

Reduced SKILL.md to a 66-line index with 1-2 line summaries per section + links to sub-files. Extracted detailed code examples and explanations into new sub-files:

- `domain-modeling.md` — Discriminated Unions, Companion Objects, Branded Types, etc.
- `declarative-style.md` — filter/map/reduce, domain events
- `test-data.md` — `as const satisfies` pattern

Existing sub-files (error-handling.md, state-modeling.md, boundary-defense.md) unchanged. Same structure applied to both EN and JA.

## Test Plan

- [x] After `npx skills add`, SKILL.md works as a pointer with resolvable relative links
- [x] Works with agents other than Claude Code

---
Generated with Claude Code
