### PR TITLE
feat: make skills publishable and installable via gh skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
-  "name": "functional-ts-principal",
+  "name": "functional-ts-principles",
   "description": "Principles for functional domain modeling in server-side TypeScript: discriminated unions, pure state transitions, Result types, and boundary defense",
   "version": "0.1.0",
   "author": {
     "name": "Kosui Iwasa"
   },
-  "repository": "https://github.com/iwasa-kosui/functional-ts-principal",
+  "repository": "https://github.com/iwasa-kosui/functional-ts-principles",
   "license": "MIT",
   "keywords": [
     "typescript",

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Kosui Iwasa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.ja.md
+++ b/README.ja.md
@@ -14,6 +14,22 @@
 
 ## インストール
 
+[`gh skill`](https://cli.github.com/manual/gh_skill)（GitHub CLI のエージェントスキル拡張）経由:
+
+```bash
+# 単一スキルをインストール（エージェント/スコープは対話で選択）
+gh skill install iwasa-kosui/functional-ts-principles functional-ts
+
+# 非対話的に Claude Code のユーザースコープへインストール
+gh skill install iwasa-kosui/functional-ts-principles functional-ts \
+  --agent claude-code --scope user
+
+# 特定リリースを固定
+gh skill install iwasa-kosui/functional-ts-principles functional-ts@v0.1.0
+```
+
+または [`skills` CLI](https://github.com/anthropics/skills) 経由:
+
 ```bash
 npx skills add iwasa-kosui/functional-ts-principles
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@ Provides principles for practicing functional domain modeling in server-side Typ
 
 ## Installation
 
+Via [`gh skill`](https://cli.github.com/manual/gh_skill) (the GitHub CLI's agent skills extension):
+
+```bash
+# Install a single skill (interactive prompt for agent/scope)
+gh skill install iwasa-kosui/functional-ts-principles functional-ts
+
+# Install non-interactively for Claude Code at user scope
+gh skill install iwasa-kosui/functional-ts-principles functional-ts \
+  --agent claude-code --scope user
+
+# Pin to a specific release
+gh skill install iwasa-kosui/functional-ts-principles functional-ts@v0.1.0
+```
+
+Or via [`skills` CLI](https://github.com/anthropics/skills):
+
 ```bash
 npx skills add iwasa-kosui/functional-ts-principles
 ```

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "functional-ts-principal",
+  "name": "functional-ts-principles",
   "version": "0.1.0",
-  "description": "Claude Code skill plugin: functional domain modeling principles for server-side TypeScript",
+  "description": "Agent skill plugin: functional domain modeling principles for server-side TypeScript",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iwasa-kosui/functional-ts-principal"
+    "url": "https://github.com/iwasa-kosui/functional-ts-principles"
   }
 }

--- a/skills/functional-ts-ja/SKILL.md
+++ b/skills/functional-ts-ja/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: functional-ts-ja
 description: サーバーサイドTypeScriptでドメインモデル、ユースケース、リポジトリ、状態遷移、ビジネスロジックを書くときに使用する。Discriminated Union、純粋関数、Result型による関数型ドメインモデリングをガイドする。
+license: MIT
 ---
 
 # Functional Domain Modeling in TypeScript

--- a/skills/functional-ts-review-ja/SKILL.md
+++ b/skills/functional-ts-review-ja/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: functional-ts-review-ja
 description: サーバーサイドTypeScriptコードを関数型ドメインモデリング原則に照らしてレビューする。class使用、メソッド記法、interface宣言、型アサーション、例外throw、網羅性チェック不足、PII保護をチェックする。
+license: MIT
 ---
 
 # Functional TypeScript Code Review

--- a/skills/functional-ts-review/SKILL.md
+++ b/skills/functional-ts-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: functional-ts-review
 description: Use when reviewing TypeScript server-side code for adherence to functional domain modeling principles. Checks for class usage, method notation, interface declarations, type assertions, thrown exceptions, missing exhaustiveness checks, and PII protection.
+license: MIT
 ---
 
 # Functional TypeScript Code Review

--- a/skills/functional-ts/SKILL.md
+++ b/skills/functional-ts/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: functional-ts
 description: Use when writing server-side TypeScript code involving domain models, use cases, repositories, state transitions, or business logic. Guides functional domain modeling with discriminated unions, pure functions, and Result types.
+license: MIT
 ---
 
 # Functional Domain Modeling in TypeScript


### PR DESCRIPTION
## Summary
- Make the four skills (`functional-ts`, `functional-ts-ja`, `functional-ts-review`, `functional-ts-review-ja`) ready for `gh skill publish` / `gh skill install`.
- Fix a typo in the canonical repository URL, add the MIT `LICENSE` file, declare `license: MIT` in each `SKILL.md` frontmatter, and document the `gh skill install` route in both READMEs.
- After this PR is merged, `gh skill publish --tag v0.1.0` will create the first release and tag the repo with the `agent-skills` topic so it shows up in `gh skill search`.

## Why
- `package.json` and `.claude-plugin/plugin.json` referenced `iwasa-kosui/functional-ts-principal` (typo). That URL is what `gh skill` records as the source of truth, so installs would have tracked a non-existent repository.
- `LICENSE` was missing at the repo root, leaving GitHub's `licenseInfo` as `null`. Without a machine-readable license, installer UIs cannot surface the terms even though the manifests already declared MIT.
- The Agent Skills specification recommends a `license` frontmatter field on each `SKILL.md`. Without it `gh skill publish` emits a warning per skill.
- The READMEs only documented the `npx skills add …` route. The `gh skill` flow exposes per-agent / per-scope installation and version pinning, which is worth surfacing to users.

## Test plan
- [x] `gh skill publish --dry-run` passes with no `license` warnings (only the optional tag protection ruleset warning remains).
- [ ] After merge, `gh skill publish --tag v0.1.0` creates the release and adds the `agent-skills` topic.
- [ ] `gh skill install iwasa-kosui/functional-ts-principles functional-ts --agent claude-code --scope user` installs the skill end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
