### PR TITLE
chore: rename to kamae-ts and introduce the Kamae concept

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
-  "name": "functional-ts-principles",
-  "description": "Principles for functional domain modeling in server-side TypeScript: discriminated unions, pure state transitions, Result types, and boundary defense",
+  "name": "kamae-ts",
+  "description": "Kamae (構え) — an extensible harness of skill plugins for designing and implementing robust server-side TypeScript applications",
   "version": "0.1.0",
   "author": {
     "name": "Kosui Iwasa"
   },
-  "repository": "https://github.com/iwasa-kosui/functional-ts-principles",
+  "repository": "https://github.com/iwasa-kosui/kamae-ts",
   "license": "MIT",
   "keywords": [
     "typescript",

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,8 +1,12 @@
 > English version: [README.md](README.md)
 
-# functional-ts-principles
+# kamae-ts
 
-サーバーサイドTypeScriptで関数型ドメインモデリングを実践するための原則を、コーディングエージェント向けスキルプラグインとして提供する。
+> _Kamae（構え）— 堅牢なTSサーバを書くために装着する姿勢・備え。_
+
+堅牢なサーバーサイドTypeScriptアプリケーションを設計・実装するための、拡張可能なスキルプラグイン集。各スキルは特定の設計関心に対する**構え**を体系化したもので、コーディングエージェントがコード生成・レビュー時に適用する。
+
+現在の構えは関数型ドメインモデリングを中心に構成されており、今後段階的に拡張されていく。
 
 ## 原則の概要
 
@@ -18,20 +22,20 @@
 
 ```bash
 # 単一スキルをインストール（エージェント/スコープは対話で選択）
-gh skill install iwasa-kosui/functional-ts-principles functional-ts
+gh skill install iwasa-kosui/kamae-ts functional-ts
 
 # 非対話的に Claude Code のユーザースコープへインストール
-gh skill install iwasa-kosui/functional-ts-principles functional-ts \
+gh skill install iwasa-kosui/kamae-ts functional-ts \
   --agent claude-code --scope user
 
 # 特定リリースを固定
-gh skill install iwasa-kosui/functional-ts-principles functional-ts@v0.1.0
+gh skill install iwasa-kosui/kamae-ts functional-ts@v0.1.0
 ```
 
 または [`skills` CLI](https://github.com/anthropics/skills) 経由:
 
 ```bash
-npx skills add iwasa-kosui/functional-ts-principles
+npx skills add iwasa-kosui/kamae-ts
 ```
 
 ## 提供スキル

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 > 日本語版: [README.ja.md](README.ja.md)
 
-# functional-ts-principles
+# kamae-ts
 
-Provides principles for practicing functional domain modeling in server-side TypeScript as skill plugins for coding agents.
+> _Kamae (構え) — a stance of readiness._
+
+An extensible harness of skill plugins for designing and implementing robust server-side TypeScript applications. Each skill encodes a *kamae* — a practiced stance for a specific design concern — that coding agents apply when generating or reviewing code.
+
+The current stances focus on functional domain modeling; more will be added over time.
 
 ## Overview of Principles
 
@@ -18,20 +22,20 @@ Via [`gh skill`](https://cli.github.com/manual/gh_skill) (the GitHub CLI's agent
 
 ```bash
 # Install a single skill (interactive prompt for agent/scope)
-gh skill install iwasa-kosui/functional-ts-principles functional-ts
+gh skill install iwasa-kosui/kamae-ts functional-ts
 
 # Install non-interactively for Claude Code at user scope
-gh skill install iwasa-kosui/functional-ts-principles functional-ts \
+gh skill install iwasa-kosui/kamae-ts functional-ts \
   --agent claude-code --scope user
 
 # Pin to a specific release
-gh skill install iwasa-kosui/functional-ts-principles functional-ts@v0.1.0
+gh skill install iwasa-kosui/kamae-ts functional-ts@v0.1.0
 ```
 
 Or via [`skills` CLI](https://github.com/anthropics/skills):
 
 ```bash
-npx skills add iwasa-kosui/functional-ts-principles
+npx skills add iwasa-kosui/kamae-ts
 ```
 
 ## Provided Skills

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "functional-ts-principles",
+  "name": "kamae-ts",
   "version": "0.1.0",
-  "description": "Agent skill plugin: functional domain modeling principles for server-side TypeScript",
+  "description": "Kamae (構え) — an extensible harness of skill plugins for designing and implementing robust server-side TypeScript applications",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iwasa-kosui/functional-ts-principles"
+    "url": "https://github.com/iwasa-kosui/kamae-ts"
   }
 }


### PR DESCRIPTION
## Summary

Rename the repository to `kamae-ts`, reflecting the broadened scope from "functional domain modeling principles" to "an extensible harness for designing and implementing robust server-side TypeScript applications."

- **Kamae (構え)**: a martial-arts stance — a practiced posture absorbed through repetition. Each skill encodes a single kamae; the repository is the dojo that bundles them.
- The TypeScript Type and the Japanese 型 align semantically — naming the bundle `kamae` matches the underlying reality (a collection of typed designs).
- Looking ahead to skill expansion (branded-types, schema-factory, unique-symbol-brand, etc.), the narrower prefix `functional-` is dropped.

## Changes

- `README.md` / `README.ja.md`: title, Kamae concept introduction, harness vision, install command examples
- `package.json`: `name`, `repository.url`, `description`
- `.claude-plugin/plugin.json`: `name`, `repository`, `description`

The old-name reference inside `docs/superpowers/plans/2026-04-07-bilingual-support.md` is preserved as historical record.

## Post-merge tasks (manual)

- Rename the repository on GitHub: `iwasa-kosui/functional-ts-principles` → `iwasa-kosui/kamae-ts` (Settings UI, or `gh repo rename`)
- Rename the local ghq directory and update the remote URL
- Repair worktree paths if needed (recreate as necessary)

## Test plan

- [ ] README renders correctly (title, Kamae description, install command examples)
- [ ] After the rename, `gh skill install iwasa-kosui/kamae-ts functional-ts` succeeds
- [ ] After the rename, `npx skills add iwasa-kosui/kamae-ts` succeeds

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
