### PR TITLE
ci(release): add manual workflow for version sync and GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (semver, e.g. 1.2.3 — leading "v" is stripped)'
+        required: true
+        type: string
+      draft:
+        description: 'Create as draft release'
+        required: false
+        type: boolean
+        default: false
+      prerelease:
+        description: 'Mark as prerelease'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate inputs and branch
+        id: validate
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${INPUT_VERSION#v}"
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid semver: $version"
+            exit 1
+          fi
+          tag="v$version"
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            echo "::error::Tag $tag already exists"
+            exit 1
+          fi
+          if [[ "$REF_NAME" != "main" ]]; then
+            echo "::error::Releases must be cut from main (dispatched from: $REF_NAME)"
+            exit 1
+          fi
+          {
+            echo "version=$version"
+            echo "tag=$tag"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Sync version in package.json and plugin.json
+        env:
+          VERSION: ${{ steps.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          node -e '
+            const fs = require("fs");
+            const v = process.env.VERSION;
+            for (const f of ["package.json", ".claude-plugin/plugin.json"]) {
+              const j = JSON.parse(fs.readFileSync(f, "utf8"));
+              j.version = v;
+              fs.writeFileSync(f, JSON.stringify(j, null, 2) + "\n");
+            }
+          '
+          git diff --stat
+
+      - name: Commit, tag, and push
+        env:
+          TAG: ${{ steps.validate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json .claude-plugin/plugin.json
+          git commit -m "chore(release): $TAG"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "HEAD:$GITHUB_REF_NAME"
+          git push origin "$TAG"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.validate.outputs.tag }}
+          DRAFT: ${{ inputs.draft }}
+          PRERELEASE: ${{ inputs.prerelease }}
+        run: |
+          set -euo pipefail
+          args=("$TAG" --title "$TAG" --generate-notes)
+          [[ "$DRAFT" == "true" ]] && args+=(--draft)
+          [[ "$PRERELEASE" == "true" ]] && args+=(--prerelease)
+          gh release create "${args[@]}"


### PR DESCRIPTION
## Why

Consolidate release work into a single operation. The versions in `package.json` and `.claude-plugin/plugin.json` have so far been kept in sync by hand, but since this is distributed as a Claude Code plugin, any divergence here would cause the version reported by the plugin to disagree with the actual contents. The workflow enforces the sync.

Release notes are delegated to GitHub's auto-generation (`--generate-notes`). It pairs well with our Conventional Commits practice and removes the need to maintain a separate CHANGELOG file.

## What

Adds a `workflow_dispatch`-triggered `Release` workflow at `.github/workflows/release.yml`.

Key design decisions:
- **Manual trigger only**: We do not use tag-push triggers or release-please; the release decision stays an explicit human action.
- **main only**: Fail fast if the dispatch is from any branch other than `main`.
- **Semver validation**: Strip a leading `v` from the input, and reject malformed values or collisions with existing tags before doing any work.
- **Use Node's stdlib for JSON edits**: Rather than adding a new dependency, `node -e` updates only the `version` field while preserving the 2-space indent and trailing newline.
- **Commit, tag, and push under the bot identity**: `github-actions[bot]` creates `chore(release): vX.Y.Z`, signs an annotated tag, and pushes both `main` and the tag.
- **Optional draft / prerelease inputs**: Since this is manual, leave room for case-by-case judgment.

## Caveats / Not addressed

- If branch protection forbids direct pushes to `main`, `secrets.GITHUB_TOKEN` alone will not be enough. An exception for `github-actions[bot]`, or a PAT supplied via a separate secret, will be required (not verified; will follow up if it surfaces in real use).
- If another commit lands on `main` concurrently, the fast-forward push will fail and the workflow simply errors out, expecting the operator to re-dispatch. No retry logic is built in.

## Test Plan

- [ ] From the Actions tab, dispatch `Release` with `version=1.0.1` and confirm that tag `v1.0.1` and the GitHub Release are created.
- [ ] Confirm both `package.json` and `.claude-plugin/plugin.json` have their `version` updated, and that JSON formatting (indent, trailing newline) is preserved.
- [ ] Confirm the workflow fails when an existing tag's version is supplied.
- [ ] Confirm the workflow fails when dispatched from a branch other than `main`.
- [ ] Confirm that running with `draft=true` produces a draft Release.

---
Generated with Claude Code
