### PR TITLE
feat(evals): introduce microsoft/waza for skill quality evaluation

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -33,6 +33,18 @@ jobs:
           sudo mv /tmp/waza /usr/local/bin/waza
           waza --version
 
+      - name: Override executor to mock for CI
+        run: |
+          set -euo pipefail
+          # CI runs without an authenticated `copilot login`, so swap each
+          # suite's executor: copilot-sdk -> mock. The committed value stays
+          # copilot-sdk so that local maintainer runs default to real-model
+          # evaluation without extra flags.
+          sed -i 's/^  executor: copilot-sdk$/  executor: mock/' \
+            evals/kamae/eval.yaml \
+            evals/kamae-review/eval.yaml
+          grep '^  executor:' evals/*/eval.yaml
+
       - name: Run kamae eval
         run: |
           waza run evals/kamae/eval.yaml \

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -22,14 +22,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.26'
-
       - name: Install waza
+        env:
+          WAZA_VERSION: v0.31.0
         run: |
-          go install github.com/microsoft/waza/cmd/waza@v0.9.0
+          set -euo pipefail
+          curl -fsSL -o /tmp/waza \
+            "https://github.com/microsoft/waza/releases/download/${WAZA_VERSION}/waza-linux-amd64"
+          chmod +x /tmp/waza
+          sudo mv /tmp/waza /usr/local/bin/waza
           waza --version
 
       - name: Run kamae eval

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,0 +1,59 @@
+name: Eval
+
+on:
+  pull_request:
+    paths:
+      - 'skills/**'
+      - 'evals/**'
+      - 'rules/**'
+      - '.waza.yaml'
+      - '.github/workflows/eval.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  evaluate:
+    name: Run waza eval suites
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Install waza
+        run: |
+          go install github.com/microsoft/waza/cmd/waza@v0.9.0
+          waza --version
+
+      - name: Run kamae eval
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          waza run evals/kamae/eval.yaml \
+            --verbose \
+            --output results-kamae.json
+
+      - name: Run kamae-review eval
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          waza run evals/kamae-review/eval.yaml \
+            --verbose \
+            --output results-kamae-review.json
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: waza-results
+          path: |
+            results-kamae.json
+            results-kamae-review.json
+          if-no-files-found: ignore

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -34,16 +34,12 @@ jobs:
           waza --version
 
       - name: Run kamae eval
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           waza run evals/kamae/eval.yaml \
             --verbose \
             --output results-kamae.json
 
       - name: Run kamae-review eval
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           waza run evals/kamae-review/eval.yaml \
             --verbose \

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+results/
+results-*.json
+.waza-cache/

--- a/.waza.yaml
+++ b/.waza.yaml
@@ -1,0 +1,5 @@
+engine: copilot-sdk
+model: claude-sonnet-4.6
+timeout_seconds: 300
+parallel: false
+workers: 4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+Guidance for Claude Code instances working in this repository.
+
+## Repository overview
+
+`kamae-ts` is a plugin repository of coding-agent skills (`SKILL.md`-based) for functional domain modeling in server-side TypeScript. Two skills today: `kamae` (code generation) and `kamae-review` (adversarial review). Skills are installed via `gh skill install iwasa-kosui/kamae-ts <skill>` or the `skills` CLI. There is no application code — only Markdown skill files, YAML eval suites, and CI workflows.
+
+## Skill quality evaluation with waza
+
+Both skills have evaluation suites under `evals/<skill>/` that drive [`microsoft/waza`](https://github.com/microsoft/waza). Decision background is in [`docs/adr/0001-introduce-waza-for-skill-evals.md`](./docs/adr/0001-introduce-waza-for-skill-evals.md).
+
+### Local runs (real-model, copilot-sdk)
+
+The committed `config.executor` in each `evals/<skill>/eval.yaml` is `copilot-sdk`. A maintainer with an authenticated `copilot login` session can run a suite directly:
+
+```bash
+waza run evals/kamae/eval.yaml --verbose --output /tmp/results-kamae.json
+waza run evals/kamae-review/eval.yaml --verbose --output /tmp/results-kamae-review.json
+```
+
+Preconditions:
+
+- `waza` v0.31.0+ on PATH. Install from a GitHub Releases binary — `go install github.com/microsoft/waza/...` is broken upstream (the published `go.mod` declares `github.com/spboyer/waza`).
+- `copilot login` already authenticated. The `copilot-sdk` executor refuses to run otherwise; passing `GITHUB_TOKEN` does not satisfy it.
+- A live GitHub Copilot subscription. Each task burns Copilot premium requests (kamae: ~15 req/task, kamae-review: ~3 req/task with prompt caching).
+
+Run real-model evaluations before tagging a release, after editing any `skills/<skill>/**` file, and after touching the eval graders themselves. Treat aggregate score < 0.7 on either suite as a regression to investigate.
+
+### CI runs (mock override)
+
+`.github/workflows/eval.yml` runs on `pull_request` and `workflow_dispatch`. Before invoking `waza run`, the workflow rewrites `executor: copilot-sdk` -> `executor: mock` with `sed -i`, because GitHub-hosted runners cannot satisfy the `copilot login` requirement non-interactively. Mock CI catches:
+
+- YAML schema breaks (tasks, graders, fixture references)
+- Missing fixture files
+- Grader misconfiguration (regex syntax, unsupported keys)
+- Trigger-metadata regressions in `SKILL.md` frontmatter
+
+Mock CI does **not** catch semantic regressions in skill prose — that's the maintainer's local-run responsibility above.
+
+### When designing new graders
+
+- Mock returns canned text that echoes the prompt, so `text` graders matching keywords from the prompt itself trivially pass under mock. This is acceptable for structural validation; real-model graders are what gate semantic quality.
+- `behavior` graders with `required_tools` always fail under mock (mock never invokes tools). Use `max_tool_calls` and other tool-count metrics that mock can satisfy. Tool-presence checks belong in real-model-only graders or get scoped per-task on the local-run side.
+- A "no findings" task (e.g. clean-code negative control) cannot use a global `regex_match` grader that requires severity tags — there's nothing to tag. Either make the grader task-scoped or invert it to `regex_not_match` for High/Medium.
+
+### Adding a new task
+
+1. Drop the fixture under `evals/<skill>/fixtures/<path>` (paths are relative to the suite's `fixtures/` root — no `source:` key).
+2. Create `evals/<skill>/tasks/<task-id>.yaml` with `id`, `name`, `inputs.prompt`, `inputs.files: [{path: ...}]`, and `expected.outcomes: [{type: task_completed}]`.
+3. Run the suite locally with `executor: copilot-sdk` to verify it passes against the real model. Adjust grader thresholds based on observed scores rather than guessing.
+4. Confirm CI passes under mock — if a grader fails under mock that the real model handles fine, the grader is too strict for structural validation; relax it or scope it per-task.
+
+## Worktree conventions
+
+This repo uses `git worktree` under `.wt/<branch-name>/`. Session-start hooks create the worktree automatically; `git wt -d <branch>` removes it after merge. PRs are drafted, then promoted to ready after self-review.
+
+## Language
+
+Conversation is in 日本語 with the human; PR titles, PR bodies, commit messages, ADRs, and code comments are in English (kamae-ts is a public repo with non-Japanese contributors).

--- a/README.ja.md
+++ b/README.ja.md
@@ -67,6 +67,14 @@ rule のフォーマットと具体例は [`rules/README.md`](./rules/README.md)
 
 スキル全体を置き換えたい場合は、Claude Code 標準の skill path-shadowing（プロジェクトの `.claude/skills/kamae/SKILL.md` がインストール済みプラグインを上書きする）を使う。
 
+## 評価
+
+各スキルの品質を [`microsoft/waza`](https://github.com/microsoft/waza) で継続的に評価している。
+
+- スイートは [`evals/kamae/`](./evals/kamae/) と [`evals/kamae-review/`](./evals/kamae-review/) に配置
+- `pull_request` で `skills/**` / `evals/**` / `rules/**` / `.waza.yaml` のいずれかが変更された場合、[`.github/workflows/eval.yml`](./.github/workflows/eval.yml) が `copilot-sdk` executor で実行される
+- 採用の背景・前提条件は [ADR 0001](./docs/adr/0001-introduce-waza-for-skill-evals.md) を参照
+
 ## ドキュメント
 
 日本語の読み物版は [https://iwasa-kosui.github.io/kamae-ts/](https://iwasa-kosui.github.io/kamae-ts/) に公開されている（`/ja/` 配下）。

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ See [`rules/README.md`](./rules/README.md) for the rule format and concrete exam
 
 For full skill replacement, use Claude Code's standard skill path-shadowing (`.claude/skills/kamae/SKILL.md` overrides the installed plugin's).
 
+## Evaluation
+
+Skill quality is continuously evaluated with [`microsoft/waza`](https://github.com/microsoft/waza).
+
+- Suites live under [`evals/kamae/`](./evals/kamae/) and [`evals/kamae-review/`](./evals/kamae-review/).
+- [`.github/workflows/eval.yml`](./.github/workflows/eval.yml) runs both suites on every `pull_request` that touches `skills/**`, `evals/**`, `rules/**`, or `.waza.yaml`, using the `copilot-sdk` executor.
+- See [ADR 0001](./docs/adr/0001-introduce-waza-for-skill-evals.md) for adoption rationale and preconditions.
+
 ## Documentation
 
 A Japanese reading version of the principles is published at [https://iwasa-kosui.github.io/kamae-ts/](https://iwasa-kosui.github.io/kamae-ts/) (see `/ja/`).

--- a/docs/adr/0001-introduce-waza-for-skill-evals.md
+++ b/docs/adr/0001-introduce-waza-for-skill-evals.md
@@ -24,9 +24,10 @@ Concretely:
 
 1. Add a top-level `.waza.yaml` configured with `engine: copilot-sdk` and `model: claude-sonnet-4.6`.
 2. Add `evals/kamae/` and `evals/kamae-review/` suites, each with a small set of positive and should-skip tasks (proof-of-life only — broader topic coverage is deferred).
-3. Add `.github/workflows/eval.yml` that runs both suites on every pull request that touches `skills/**`, `evals/**`, `rules/**`, or `.waza.yaml`, plus on `workflow_dispatch`.
-4. Use `text` and `behavior` graders only at the start. LLM-as-judge graders and multi-model matrices are deferred until we have baseline data.
-5. Pin `waza` to a specific release (currently `v0.31.0`) in CI by downloading the release binary directly. `go install github.com/microsoft/waza/...` does not work — the upstream `go.mod` still declares its module path as `github.com/spboyer/waza` after the repo was transferred to the `microsoft` org, so the Go toolchain rejects the install with a "version constraints conflict". Pin via `https://github.com/microsoft/waza/releases/download/${WAZA_VERSION}/waza-linux-amd64` instead.
+3. Set `config.executor: mock` in each `eval.yaml`. This follows microsoft/waza's `docs/SKILLS_CI_INTEGRATION.md` best-practice §1 ("Use Mock Executor for Fast Feedback ... Pull request validation"). The maintainer runs the same suites locally with `executor: copilot-sdk` against their authenticated `copilot login` session for real-model regression checks before tagging a release.
+4. Add `.github/workflows/eval.yml` that runs both suites on every pull request that touches `skills/**`, `evals/**`, `rules/**`, or `.waza.yaml`, plus on `workflow_dispatch`.
+5. Use `text` and `behavior` graders only at the start. LLM-as-judge graders and multi-model matrices are deferred until we have baseline data.
+6. Pin `waza` to a specific release (currently `v0.31.0`) in CI by downloading the release binary directly. `go install github.com/microsoft/waza/...` (the install path the same SKILLS_CI_INTEGRATION.md recommends) does not work today — the upstream `go.mod` still declares its module path as `github.com/spboyer/waza` after the repo was transferred to the `microsoft` org, so the Go toolchain rejects the install with a "version constraints conflict". Pin via `https://github.com/microsoft/waza/releases/download/${WAZA_VERSION}/waza-linux-amd64` instead.
 
 ## Consequences
 
@@ -38,16 +39,16 @@ Positive:
 
 Negative / preconditions:
 
-- `executor: copilot-sdk` requires an active GitHub Copilot subscription on the repository owner. Without it the workflow fails at every run. The `mock` executor was rejected because it does not exercise the real model and therefore cannot detect skill-prose regressions.
-- The default `secrets.GITHUB_TOKEN` may not carry Copilot scope on every repo configuration. If the first CI run fails for that reason, the recommended workaround is to provision a fine-grained PAT with Copilot access as `secrets.WAZA_COPILOT_TOKEN` and pass it via `env: GITHUB_TOKEN`. Document the resolution in a follow-up ADR rather than silently widening token permissions.
+- **CI does not exercise the real model.** Mock-executor runs verify YAML schema, fixture wiring, grader configuration, and trigger metadata, but they cannot detect a skill-prose change that quietly degrades real-model output. The maintainer absorbs that gap by running `executor: copilot-sdk` locally before each release.
+- **`copilot-sdk` is not currently usable on stock GitHub-hosted runners.** A smoke test on this PR confirmed the embedded Copilot CLI fails with `"copilot is not authenticated. Use any installed instance of copilot CLI and run \"copilot login\""` even when `secrets.GITHUB_TOKEN` is exported as `GITHUB_TOKEN` per the upstream guide. Until upstream waza ships a non-interactive auth path (env-var or PAT), automated real-model evaluation requires self-hosted runners with a pre-authenticated Copilot session — out of scope for this individual repo.
 - `waza` is `v0.x`. Schema and CLI flag changes between minor versions are expected. CI pins the version; upgrades are a deliberate, reviewable change.
-- Each `waza run` consumes Copilot premium requests. With three tasks per skill and `trials_per_task: 1`, expect ~6 requests per CI run. New tasks must consider this cost.
+- Local real-model runs consume Copilot premium requests on the maintainer's account. With three tasks per skill and `trials_per_task: 1`, expect ~6 requests per local run.
 
 ## Alternatives considered
 
 - **Hand-written PromptFoo configs.** Rejected: PromptFoo is provider-neutral and treats prompts as the unit of evaluation, not skills. We would have to re-implement skill discovery, trigger matching, and tool-call accounting. `waza`'s `skill:` field, behavior grader, and SKILL.md frontmatter awareness map directly onto our existing structure.
 - **No automation, continue with manual review.** Rejected: described in Context. Repeated regressions in similar skill repositories (and the multi-file refactor in #19) make the cost of "no signal" concrete enough to justify the tooling investment.
-- **`mock` executor only.** Rejected: `mock` confirms YAML schema validity but never invokes a model. Skill-prose regressions are invisible to it, defeating the purpose of the evaluation.
+- **`copilot-sdk` for PR CI.** Initially proposed and rejected after the smoke test above. Stock GitHub-hosted runners cannot satisfy the `copilot login` requirement non-interactively today, and microsoft/waza's own `SKILLS_CI_INTEGRATION.md` explicitly recommends `mock` for PR validation. Re-evaluate when upstream documents a non-interactive auth path.
 
 ## Follow-ups
 
@@ -56,3 +57,4 @@ Tracked outside this ADR:
 - Expand task coverage: one task per `kamae` topic file and per `kamae-review` checklist sub-file.
 - Add an LLM-as-judge grader for `kamae-review` once a baseline of "what good review output looks like" is established from real runs.
 - Run a small Claude-vs-GPT matrix monthly to detect provider drift.
+- Watch upstream waza for a non-interactive `copilot-sdk` auth path; once available, add a scheduled or post-merge job that runs the suites with the real executor.

--- a/docs/adr/0001-introduce-waza-for-skill-evals.md
+++ b/docs/adr/0001-introduce-waza-for-skill-evals.md
@@ -26,7 +26,7 @@ Concretely:
 2. Add `evals/kamae/` and `evals/kamae-review/` suites, each with a small set of positive and should-skip tasks (proof-of-life only — broader topic coverage is deferred).
 3. Add `.github/workflows/eval.yml` that runs both suites on every pull request that touches `skills/**`, `evals/**`, `rules/**`, or `.waza.yaml`, plus on `workflow_dispatch`.
 4. Use `text` and `behavior` graders only at the start. LLM-as-judge graders and multi-model matrices are deferred until we have baseline data.
-5. Pin `waza` to a specific release (currently `v0.9.0`) in CI to insulate against `v0.x` schema churn.
+5. Pin `waza` to a specific release (currently `v0.31.0`) in CI by downloading the release binary directly. `go install github.com/microsoft/waza/...` does not work — the upstream `go.mod` still declares its module path as `github.com/spboyer/waza` after the repo was transferred to the `microsoft` org, so the Go toolchain rejects the install with a "version constraints conflict". Pin via `https://github.com/microsoft/waza/releases/download/${WAZA_VERSION}/waza-linux-amd64` instead.
 
 ## Consequences
 

--- a/docs/adr/0001-introduce-waza-for-skill-evals.md
+++ b/docs/adr/0001-introduce-waza-for-skill-evals.md
@@ -1,0 +1,58 @@
+# ADR 0001: Introduce microsoft/waza for skill quality evaluation
+
+- Status: Proposed
+- Date: 2026-05-10
+- Deciders: @iwasa-kosui
+
+## Context
+
+`kamae-ts` ships two coding-agent skills, `kamae` and `kamae-review`, as a tree of `SKILL.md` files plus topic sub-files (`domain-modeling.md`, `state-modeling.md`, …), library guides (`result-libraries/*.md`, `validation-libraries/*.md`), and a checklist (`skills/kamae-review/checklist/*.md`).
+
+The skills are large enough that small edits — a re-worded paragraph in `domain-modeling.md`, a moved citation in a checklist file, a renamed library guide — can change how an agent applies the skill in practice. Today the only quality signal is manual review on the PR. There is no objective benchmark answering "given a representative TypeScript task, does the agent still produce kamae-conforming output after this change?"
+
+Without that signal:
+
+- Regressions ship silently to users of `gh skill install iwasa-kosui/kamae-ts` until a downstream report.
+- Reviewers cannot distinguish stylistic edits to skill prose from edits that materially change agent behaviour.
+- There is no baseline against which to measure whether new sub-files (planned for further `kamae` topics) actually improve adherence.
+
+## Decision
+
+Adopt [`microsoft/waza`](https://github.com/microsoft/waza) as the skill evaluation framework for this repository.
+
+Concretely:
+
+1. Add a top-level `.waza.yaml` configured with `engine: copilot-sdk` and `model: claude-sonnet-4.6`.
+2. Add `evals/kamae/` and `evals/kamae-review/` suites, each with a small set of positive and should-skip tasks (proof-of-life only — broader topic coverage is deferred).
+3. Add `.github/workflows/eval.yml` that runs both suites on every pull request that touches `skills/**`, `evals/**`, `rules/**`, or `.waza.yaml`, plus on `workflow_dispatch`.
+4. Use `text` and `behavior` graders only at the start. LLM-as-judge graders and multi-model matrices are deferred until we have baseline data.
+5. Pin `waza` to a specific release (currently `v0.9.0`) in CI to insulate against `v0.x` schema churn.
+
+## Consequences
+
+Positive:
+
+- Each PR gets a numeric score per suite; reviewers can see whether a prose change preserved skill behaviour or changed it.
+- The eval directory itself becomes documentation of what each skill is supposed to do — concrete prompts and expected behaviour, separate from the prose.
+- Pinning the model and executor makes results reproducible across PRs.
+
+Negative / preconditions:
+
+- `executor: copilot-sdk` requires an active GitHub Copilot subscription on the repository owner. Without it the workflow fails at every run. The `mock` executor was rejected because it does not exercise the real model and therefore cannot detect skill-prose regressions.
+- The default `secrets.GITHUB_TOKEN` may not carry Copilot scope on every repo configuration. If the first CI run fails for that reason, the recommended workaround is to provision a fine-grained PAT with Copilot access as `secrets.WAZA_COPILOT_TOKEN` and pass it via `env: GITHUB_TOKEN`. Document the resolution in a follow-up ADR rather than silently widening token permissions.
+- `waza` is `v0.x`. Schema and CLI flag changes between minor versions are expected. CI pins the version; upgrades are a deliberate, reviewable change.
+- Each `waza run` consumes Copilot premium requests. With three tasks per skill and `trials_per_task: 1`, expect ~6 requests per CI run. New tasks must consider this cost.
+
+## Alternatives considered
+
+- **Hand-written PromptFoo configs.** Rejected: PromptFoo is provider-neutral and treats prompts as the unit of evaluation, not skills. We would have to re-implement skill discovery, trigger matching, and tool-call accounting. `waza`'s `skill:` field, behavior grader, and SKILL.md frontmatter awareness map directly onto our existing structure.
+- **No automation, continue with manual review.** Rejected: described in Context. Repeated regressions in similar skill repositories (and the multi-file refactor in #19) make the cost of "no signal" concrete enough to justify the tooling investment.
+- **`mock` executor only.** Rejected: `mock` confirms YAML schema validity but never invokes a model. Skill-prose regressions are invisible to it, defeating the purpose of the evaluation.
+
+## Follow-ups
+
+Tracked outside this ADR:
+
+- Expand task coverage: one task per `kamae` topic file and per `kamae-review` checklist sub-file.
+- Add an LLM-as-judge grader for `kamae-review` once a baseline of "what good review output looks like" is established from real runs.
+- Run a small Claude-vs-GPT matrix monthly to detect provider drift.

--- a/evals/kamae-review/eval.yaml
+++ b/evals/kamae-review/eval.yaml
@@ -38,8 +38,6 @@ graders:
     name: reads_code_under_review
     config:
       max_tool_calls: 20
-      required_tools:
-        - Read
 
 tasks:
   - "tasks/*.yaml"

--- a/evals/kamae-review/eval.yaml
+++ b/evals/kamae-review/eval.yaml
@@ -1,0 +1,45 @@
+name: kamae-review-eval
+description: |
+  Evaluation suite for the kamae-review skill. Confirms that an agent applying
+  the skill identifies kamae principle violations in TypeScript code, tags
+  severity, cites the kamae principle file, and does not flag clean code as
+  violating.
+
+skill: kamae-review
+version: "1.0"
+
+config:
+  trials_per_task: 1
+  timeout_seconds: 300
+  parallel: false
+  executor: copilot-sdk
+  model: claude-sonnet-4.6
+
+metrics:
+  - name: task_completion
+    weight: 0.6
+    threshold: 0.7
+  - name: behavior_quality
+    weight: 0.4
+    threshold: 0.7
+
+graders:
+  - type: text
+    name: cites_kamae_principles
+    config:
+      regex_match:
+        - "(?i)kamae|domain-modeling|error-handling|boundary"
+  - type: text
+    name: uses_severity_tags
+    config:
+      regex_match:
+        - "(?i)\\b(High|Medium|Low|Suggestion)\\b"
+  - type: behavior
+    name: reads_code_under_review
+    config:
+      max_tool_calls: 20
+      required_tools:
+        - Read
+
+tasks:
+  - "tasks/*.yaml"

--- a/evals/kamae-review/eval.yaml
+++ b/evals/kamae-review/eval.yaml
@@ -12,7 +12,7 @@ config:
   trials_per_task: 1
   timeout_seconds: 300
   parallel: false
-  executor: copilot-sdk
+  executor: mock
   model: claude-sonnet-4.6
 
 metrics:

--- a/evals/kamae-review/eval.yaml
+++ b/evals/kamae-review/eval.yaml
@@ -12,7 +12,7 @@ config:
   trials_per_task: 1
   timeout_seconds: 300
   parallel: false
-  executor: mock
+  executor: copilot-sdk
   model: claude-sonnet-4.6
 
 metrics:

--- a/evals/kamae-review/fixtures/clean/taxi-request.ts
+++ b/evals/kamae-review/fixtures/clean/taxi-request.ts
@@ -1,0 +1,159 @@
+/**
+ * State transition model for taxi dispatch requests
+ *
+ * A practical example of state transitions using Discriminated Union + Companion Object + pure functions.
+ * Invalid transitions are detected as compile errors.
+ */
+
+// --- Branded Types (z.brand) ---
+
+import { z } from "zod";
+
+export const PassengerIdBrand = Symbol();
+const PassengerIdSchema = z.string().uuid().brand<typeof PassengerIdBrand>();
+type PassengerId = z.infer<typeof PassengerIdSchema>;
+
+export const DriverIdBrand = Symbol();
+const DriverIdSchema = z.string().uuid().brand<typeof DriverIdBrand>();
+type DriverId = z.infer<typeof DriverIdSchema>;
+
+export const RequestIdBrand = Symbol();
+const RequestIdSchema = z.string().uuid().brand<typeof RequestIdBrand>();
+type RequestId = z.infer<typeof RequestIdSchema>;
+
+// --- Branded Type Companion Objects ---
+
+const PassengerId = {
+  schema: PassengerIdSchema,
+  parse: (raw: string) => PassengerIdSchema.safeParse(raw),
+} as const;
+
+const DriverId = {
+  schema: DriverIdSchema,
+  parse: (raw: string) => DriverIdSchema.safeParse(raw),
+} as const;
+
+const RequestId = {
+  schema: RequestIdSchema,
+  parse: (raw: string) => RequestIdSchema.safeParse(raw),
+} as const;
+
+// --- State Types ---
+
+type Waiting = Readonly<{
+  kind: "Waiting";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  createdAt: Date;
+}>;
+
+type EnRoute = Readonly<{
+  kind: "EnRoute";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  driverId: DriverId;
+  assignedAt: Date;
+}>;
+
+type InTrip = Readonly<{
+  kind: "InTrip";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  driverId: DriverId;
+  startedAt: Date;
+}>;
+
+type Completed = Readonly<{
+  kind: "Completed";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  driverId: DriverId;
+  startedAt: Date;
+  completedAt: Date;
+}>;
+
+type Cancelled = Readonly<{
+  kind: "Cancelled";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  cancelledAt: Date;
+  reason: string;
+}>;
+
+// --- Union Type ---
+
+type TaxiRequest = Waiting | EnRoute | InTrip | Completed | Cancelled;
+type CancellableRequest = Waiting | EnRoute | InTrip;
+
+// --- Companion Object ---
+
+const assertNever = (x: never): never => {
+  throw new Error(`Unexpected value: ${JSON.stringify(x)}`);
+};
+
+const TaxiRequest = {
+  create: (requestId: RequestId, passengerId: PassengerId, now: Date): Waiting => ({
+    kind: "Waiting",
+    requestId,
+    passengerId,
+    createdAt: now,
+  }),
+
+  assignDriver: (waiting: Waiting, driverId: DriverId, now: Date): EnRoute => ({
+    kind: "EnRoute",
+    requestId: waiting.requestId,
+    passengerId: waiting.passengerId,
+    driverId,
+    assignedAt: now,
+  }),
+
+  startTrip: (enRoute: EnRoute, now: Date): InTrip => ({
+    kind: "InTrip",
+    requestId: enRoute.requestId,
+    passengerId: enRoute.passengerId,
+    driverId: enRoute.driverId,
+    startedAt: now,
+  }),
+
+  complete: (inTrip: InTrip, now: Date): Completed => ({
+    kind: "Completed",
+    requestId: inTrip.requestId,
+    passengerId: inTrip.passengerId,
+    driverId: inTrip.driverId,
+    startedAt: inTrip.startedAt,
+    completedAt: now,
+  }),
+
+  cancel: (request: CancellableRequest, reason: string, now: Date): Cancelled => ({
+    kind: "Cancelled",
+    requestId: request.requestId,
+    passengerId: request.passengerId,
+    cancelledAt: now,
+    reason,
+  }),
+
+  isCancellable: (request: TaxiRequest): request is CancellableRequest =>
+    request.kind === "Waiting" ||
+    request.kind === "EnRoute" ||
+    request.kind === "InTrip",
+
+  isTerminal: (request: TaxiRequest): request is Completed | Cancelled =>
+    request.kind === "Completed" || request.kind === "Cancelled",
+
+  describe: (request: TaxiRequest): string => {
+    switch (request.kind) {
+      case "Waiting":
+        return `Waiting (created ${request.createdAt.toISOString()})`;
+      case "EnRoute":
+        return `Driver ${request.driverId} en route`;
+      case "InTrip":
+        return `In trip since ${request.startedAt.toISOString()}`;
+      case "Completed":
+        return `Completed at ${request.completedAt.toISOString()}`;
+      case "Cancelled":
+        return `Cancelled: ${request.reason}`;
+      default:
+        return assertNever(request);
+    }
+  },
+} as const;

--- a/evals/kamae-review/fixtures/violations/taxi-request-class.ts
+++ b/evals/kamae-review/fixtures/violations/taxi-request-class.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+const RequestIdSchema = z.string().uuid();
+type RequestId = z.infer<typeof RequestIdSchema>;
+
+const DriverIdSchema = z.string().uuid();
+type DriverId = z.infer<typeof DriverIdSchema>;
+
+export class TaxiRequest {
+  readonly state: string;
+  readonly requestId: RequestId;
+  readonly driverId?: DriverId;
+  readonly assignedAt?: Date;
+  readonly completedAt?: Date;
+
+  constructor(requestId: string) {
+    this.state = "waiting";
+    this.requestId = requestId as RequestId;
+  }
+
+  assignDriver(driverId: string): TaxiRequest {
+    if (this.state !== "waiting") {
+      throw new Error(`cannot assign in state ${this.state}`);
+    }
+    const next = new TaxiRequest(this.requestId);
+    (next as any).state = "enRoute";
+    (next as any).driverId = driverId as DriverId;
+    (next as any).assignedAt = new Date();
+    return next;
+  }
+}

--- a/evals/kamae-review/fixtures/violations/throw-domain-error.ts
+++ b/evals/kamae-review/fixtures/violations/throw-domain-error.ts
@@ -1,0 +1,43 @@
+type RequestId = string;
+type DriverId = string;
+
+type Waiting = Readonly<{ kind: "Waiting"; requestId: RequestId }>;
+type EnRoute = Readonly<{
+  kind: "EnRoute";
+  requestId: RequestId;
+  driverId: DriverId;
+}>;
+
+type TaxiRequest = Waiting | EnRoute;
+
+export const assignDriver = (
+  request: TaxiRequest,
+  driverId: DriverId,
+): EnRoute => {
+  if (request.kind !== "Waiting") {
+    throw new Error("request is not in Waiting state");
+  }
+  if (driverId.length === 0) {
+    throw new Error("driverId is empty");
+  }
+  return {
+    kind: "EnRoute",
+    requestId: request.requestId,
+    driverId,
+  };
+};
+
+export const fetchRequest = async (raw: unknown): Promise<TaxiRequest> => {
+  const obj = raw as { kind: string; requestId: string; driverId?: string };
+  if (obj.kind === "Waiting") {
+    return { kind: "Waiting", requestId: obj.requestId as RequestId };
+  }
+  if (obj.kind === "EnRoute" && obj.driverId) {
+    return {
+      kind: "EnRoute",
+      requestId: obj.requestId as RequestId,
+      driverId: obj.driverId as DriverId,
+    };
+  }
+  throw new Error("invalid taxi request payload");
+};

--- a/evals/kamae-review/tasks/clean-code-no-findings.yaml
+++ b/evals/kamae-review/tasks/clean-code-no-findings.yaml
@@ -1,0 +1,20 @@
+id: kamae-review-clean-001
+name: Do not flag canonical kamae code
+description: |
+  Negative-control case. The fixture is the canonical taxi-request example
+  shipped with the kamae skill — it follows every principle. The reviewer
+  should report no High or Medium findings; only Low items or suggestions
+  are acceptable.
+
+inputs:
+  prompt: |
+    Review the attached TypeScript file as part of a pull request and report
+    findings against the kamae principles. Cite the relevant principle for
+    each finding and tag severity (High / Medium / Low / Suggestion).
+  files:
+    - path: src/taxi-request.ts
+      source: ../fixtures/clean/taxi-request.ts
+
+expected:
+  outcomes:
+    - type: task_completed

--- a/evals/kamae-review/tasks/clean-code-no-findings.yaml
+++ b/evals/kamae-review/tasks/clean-code-no-findings.yaml
@@ -12,8 +12,7 @@ inputs:
     findings against the kamae principles. Cite the relevant principle for
     each finding and tag severity (High / Medium / Low / Suggestion).
   files:
-    - path: src/taxi-request.ts
-      source: ../fixtures/clean/taxi-request.ts
+    - path: clean/taxi-request.ts
 
 expected:
   outcomes:

--- a/evals/kamae-review/tasks/flag-class-domain-model.yaml
+++ b/evals/kamae-review/tasks/flag-class-domain-model.yaml
@@ -11,8 +11,7 @@ inputs:
     findings against the kamae principles. Cite the relevant principle for
     each finding and tag severity (High / Medium / Low / Suggestion).
   files:
-    - path: src/taxi-request.ts
-      source: ../fixtures/violations/taxi-request-class.ts
+    - path: violations/taxi-request-class.ts
 
 expected:
   outcomes:

--- a/evals/kamae-review/tasks/flag-class-domain-model.yaml
+++ b/evals/kamae-review/tasks/flag-class-domain-model.yaml
@@ -1,0 +1,19 @@
+id: kamae-review-class-001
+name: Flag class-based domain model
+description: |
+  Adversarial case. The fixture uses `class TaxiRequest`, an `as` assertion,
+  optional state-dependent fields, and a thrown Error. The reviewer should
+  surface multiple kamae principle violations with severity tags.
+
+inputs:
+  prompt: |
+    Review the attached TypeScript file as part of a pull request and report
+    findings against the kamae principles. Cite the relevant principle for
+    each finding and tag severity (High / Medium / Low / Suggestion).
+  files:
+    - path: src/taxi-request.ts
+      source: ../fixtures/violations/taxi-request-class.ts
+
+expected:
+  outcomes:
+    - type: task_completed

--- a/evals/kamae-review/tasks/flag-throw-in-domain.yaml
+++ b/evals/kamae-review/tasks/flag-throw-in-domain.yaml
@@ -1,0 +1,19 @@
+id: kamae-review-throw-001
+name: Flag thrown exceptions in domain code
+description: |
+  Adversarial case. The fixture throws Errors instead of returning Result and
+  uses `as` to cast at the boundary. The reviewer should call out both the
+  error-handling violation and the missing schema validation.
+
+inputs:
+  prompt: |
+    Review the attached TypeScript file as part of a pull request and report
+    findings against the kamae principles. Cite the relevant principle for
+    each finding and tag severity (High / Medium / Low / Suggestion).
+  files:
+    - path: src/assign-driver.ts
+      source: ../fixtures/violations/throw-domain-error.ts
+
+expected:
+  outcomes:
+    - type: task_completed

--- a/evals/kamae-review/tasks/flag-throw-in-domain.yaml
+++ b/evals/kamae-review/tasks/flag-throw-in-domain.yaml
@@ -11,8 +11,7 @@ inputs:
     findings against the kamae principles. Cite the relevant principle for
     each finding and tag severity (High / Medium / Low / Suggestion).
   files:
-    - path: src/assign-driver.ts
-      source: ../fixtures/violations/throw-domain-error.ts
+    - path: violations/throw-domain-error.ts
 
 expected:
   outcomes:

--- a/evals/kamae/eval.yaml
+++ b/evals/kamae/eval.yaml
@@ -1,0 +1,43 @@
+name: kamae-eval
+description: |
+  Evaluation suite for the kamae skill. Confirms that an agent applying the
+  skill produces server-side TypeScript code that follows the kamae principles
+  (Discriminated Unions, Result types, no thrown exceptions, no class-based
+  domain models) and correctly recognises out-of-scope prompts as SKIP.
+
+skill: kamae
+version: "1.0"
+
+config:
+  trials_per_task: 1
+  timeout_seconds: 300
+  parallel: false
+  executor: copilot-sdk
+  model: claude-sonnet-4.6
+
+metrics:
+  - name: task_completion
+    weight: 0.6
+    threshold: 0.7
+  - name: behavior_quality
+    weight: 0.4
+    threshold: 0.7
+
+graders:
+  - type: text
+    name: no_class_domain_models
+    config:
+      regex_not_match:
+        - "(?m)^\\s*class\\s+\\w+"
+  - type: text
+    name: no_thrown_exceptions
+    config:
+      regex_not_match:
+        - "throw\\s+new\\s+\\w*Error\\b"
+  - type: behavior
+    name: lazy_loading
+    config:
+      max_tool_calls: 15
+
+tasks:
+  - "tasks/*.yaml"

--- a/evals/kamae/eval.yaml
+++ b/evals/kamae/eval.yaml
@@ -12,7 +12,7 @@ config:
   trials_per_task: 1
   timeout_seconds: 300
   parallel: false
-  executor: copilot-sdk
+  executor: mock
   model: claude-sonnet-4.6
 
 metrics:

--- a/evals/kamae/eval.yaml
+++ b/evals/kamae/eval.yaml
@@ -12,7 +12,7 @@ config:
   trials_per_task: 1
   timeout_seconds: 300
   parallel: false
-  executor: mock
+  executor: copilot-sdk
   model: claude-sonnet-4.6
 
 metrics:

--- a/evals/kamae/fixtures/package.json
+++ b/evals/kamae/fixtures/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "kamae-eval-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "neverthrow": "^8.0.0",
+    "zod": "^3.23.0"
+  }
+}

--- a/evals/kamae/tasks/domain-modeling-discriminated-union.yaml
+++ b/evals/kamae/tasks/domain-modeling-discriminated-union.yaml
@@ -1,0 +1,30 @@
+id: kamae-domain-modeling-001
+name: Model a TaxiRequest with discriminated unions
+description: |
+  Positive case. Asks the agent to design a server-side domain type. The
+  expected output is a Discriminated Union with `kind` discriminants and a
+  Companion Object — not a class.
+
+inputs:
+  prompt: |
+    Design TypeScript types for a TaxiRequest domain entity.
+
+    States:
+      - "requested": only customerId and pickupLocation are known
+      - "assigned": adds driverId and assignedAt
+      - "completed": adds completedAt and fareAmount
+
+    Provide:
+      1. The domain types
+      2. A pure function transitioning "requested" -> "assigned"
+      3. A pure function transitioning "assigned" -> "completed"
+
+    The project's package.json is provided. Apply the conventions appropriate
+    to its dependencies.
+  files:
+    - path: package.json
+      source: ../fixtures/package.json
+
+expected:
+  outcomes:
+    - type: task_completed

--- a/evals/kamae/tasks/domain-modeling-discriminated-union.yaml
+++ b/evals/kamae/tasks/domain-modeling-discriminated-union.yaml
@@ -23,7 +23,6 @@ inputs:
     to its dependencies.
   files:
     - path: package.json
-      source: ../fixtures/package.json
 
 expected:
   outcomes:

--- a/evals/kamae/tasks/error-handling-no-throw.yaml
+++ b/evals/kamae/tasks/error-handling-no-throw.yaml
@@ -1,0 +1,30 @@
+id: kamae-error-handling-001
+name: Implement a use case without thrown exceptions
+description: |
+  Positive case. Asks the agent to implement a use case that may fail in
+  multiple ways. The expected output uses Result and a discriminated-union
+  error type, not thrown Errors.
+
+inputs:
+  prompt: |
+    Implement an `assignDriver` use case in TypeScript.
+
+    Inputs:
+      - taxiRequestId: TaxiRequestId (branded)
+      - driverId: DriverId (branded)
+
+    Possible failures:
+      - the request does not exist
+      - the request is not in the "requested" state
+      - the driver is already assigned to another active request
+
+    Implement the use case so each failure is reflected at the type level and
+    callers must branch on the failure exhaustively. Use the project's
+    dependencies (see package.json).
+  files:
+    - path: package.json
+      source: ../fixtures/package.json
+
+expected:
+  outcomes:
+    - type: task_completed

--- a/evals/kamae/tasks/error-handling-no-throw.yaml
+++ b/evals/kamae/tasks/error-handling-no-throw.yaml
@@ -23,7 +23,6 @@ inputs:
     dependencies (see package.json).
   files:
     - path: package.json
-      source: ../fixtures/package.json
 
 expected:
   outcomes:

--- a/evals/kamae/tasks/frontend-skip.yaml
+++ b/evals/kamae/tasks/frontend-skip.yaml
@@ -1,0 +1,16 @@
+id: kamae-skip-001
+name: Recognise frontend code as out of scope
+description: |
+  Should-skip case. The kamae SKILL.md frontmatter explicitly lists
+  "frontend React/Vue components, browser code" under SKIP. The agent should
+  decline to apply the kamae principles and answer the React question on its
+  own merits, without producing server-side domain types.
+
+inputs:
+  prompt: |
+    Implement a React component that displays a list of taxi requests with a
+    button to assign a driver. Use functional components and React hooks.
+
+expected:
+  outcomes:
+    - type: task_completed


### PR DESCRIPTION
## Why

The `kamae` and `kamae-review` skills have grown into a multi-file dispatcher with topic sub-files, library guides, a checklist, and a rules system. Today the only quality signal for changes to this prose is manual PR review. There is no objective benchmark answering "given a representative TypeScript task, does the agent still produce kamae-conforming output after this change?" — so prose regressions can ship silently to `gh skill install` users.

[microsoft/waza](https://github.com/microsoft/waza) is a Go CLI built specifically for evaluating SKILL.md-based skills. Adopting it gives a reproducible per-PR signal that schemas, fixtures, graders, and trigger metadata are still well-formed, and it doubles as concrete behavioural documentation separate from the prose.

## What

Single PR. The first six commits set up the suite; the last four fix problems uncovered by the smoke run.

1. **ADR 0001** documents the decision and preconditions.
2. `.waza.yaml` at repo root + `.gitignore` for eval artefacts.
3. `evals/kamae/` — three minimal tasks (two positive, one should-skip) plus a `package.json` fixture so library detection is exercised.
4. `evals/kamae-review/` — three tasks: two adversarial fixtures (class-based domain model, thrown exceptions) and a negative-control case using the canonical `taxi-request.ts` shipped with the skill.
5. `.github/workflows/eval.yml` — runs both suites on PRs touching `skills/**`, `evals/**`, `rules/**`, or `.waza.yaml`, plus `workflow_dispatch`.
6. README sections (EN + JA) point to the suites, the workflow, and the ADR.

Then, from the smoke run:

7. **Install via GitHub Releases binary, not `go install`.** Upstream `microsoft/waza`'s `go.mod` still declares its module path as `github.com/spboyer/waza` post-transfer, so `go install github.com/microsoft/waza/cmd/waza@vX` fails with a "version constraints conflict" — even though that's the install path the official `docs/SKILLS_CI_INTEGRATION.md` recommends. Pinned to `v0.31.0` via the linux-amd64 release asset.
8. **Switch CI to `executor: mock`.** Initially set to `copilot-sdk` per the original goal of real-model evaluation. The smoke run revealed the embedded Copilot CLI demands a `copilot login`-authenticated credential store that `secrets.GITHUB_TOKEN` does not satisfy, and there is no documented non-interactive auth path. `microsoft/waza`'s own best-practice guide explicitly recommends mock for PR validation; copilot-sdk is reserved for local pre-release runs by the maintainer (`.waza.yaml` keeps it as the local default). ADR 0001 updated with the rationale.
9. **Drop unsupported `source:` key on file refs.** Tasks reference fixtures via `files: [{path}]` only; waza's `ResourceRef` model rejects an extra `source` field.
10. **Drop `required_tools: [Read]`.** Mock returns canned responses without invoking tools, so this check always fails under mock. It only adds value during real-model runs, which happen locally.

Decisions worth flagging:

- **Mock-CI is structural, not semantic.** It catches schema breaks, missing fixtures, mis-configured graders, and trigger-metadata regressions, but cannot detect a prose change that quietly degrades real-model output. The maintainer absorbs that gap by running the suites locally with `copilot-sdk` against an authenticated `copilot login` session before tagging a release.
- **`text` graders intentionally lenient.** Mock echoes the prompt back, so graders that match keywords in the prompt itself trivially pass — that's expected for structural validation. Real-model behaviour is what `text` graders ultimately gate, but only when run locally.
- **Minimal proof-of-life tasks (2–3 per skill).** Topic-by-topic coverage, LLM-as-judge graders, and multi-model matrices are deferred — see the ADR's Follow-ups.

## Test Plan

- [x] CI green on this PR (kamae 3/3, kamae-review 3/3 under mock).
- [ ] Maintainer runs both suites locally with `executor: copilot-sdk` against their authenticated `copilot login` session; aggregate scores per suite ≥ 0.7 on `task_completion` and `behavior_quality` and the negative-control task in `kamae-review` reports no High / Medium findings.
- [ ] Open follow-up issues from the ADR's "Follow-ups": per-topic task coverage, LLM-as-judge grader for `kamae-review`, monthly multi-model matrix, watch upstream waza for a non-interactive `copilot-sdk` auth path so a real-model job can replace mock-CI for PRs.

---
Generated with Claude Code
