### PR TITLE
docs(readme): add kamae-ts logo to README header

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="./docs/assets/logo.svg" alt="kamae-ts" height="120">
+</p>
+
 > English version: [README.md](README.md)
 
 # kamae-ts

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="./docs/assets/logo.svg" alt="kamae-ts" height="120">
+</p>
+
 > 日本語版: [README.ja.md](README.ja.md)
 
 # kamae-ts

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 240" width="720" height="240">
+  <title>kamae-ts — horizontal lockup</title>
+
+  <!-- Icon -->
+  <g>
+    <rect width="240" height="240" rx="36" fill="#3178C6"/>
+
+    <g fill="#ffffff">
+      <circle cx="120" cy="40" r="11"/>
+      <rect x="116" y="50" width="8" height="10"/>
+      <path d="M80 84 L114 58 L120 86 L126 58 L160 84 L154 132 L86 132 Z"/>
+      <path d="M80 84 L50 110 L54 130 L98 116 L100 100 L90 90 Z"/>
+      <path d="M160 84 L190 110 L186 130 L142 116 L140 100 L150 90 Z"/>
+    </g>
+
+    <rect x="82" y="130" width="76" height="7" rx="1" fill="#0f172a"/>
+
+    <g fill="#ffffff">
+      <path d="M82 137 L158 137 L162 158 L78 158 Z"/>
+      <path d="M78 158 L64 200 L62 220 L94 220 L106 200 L108 158 Z"/>
+      <path d="M162 158 L176 200 L178 220 L146 220 L134 200 L132 158 Z"/>
+    </g>
+  </g>
+
+  <!-- Wordmark -->
+  <text x="280" y="150"
+        font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Display', system-ui, 'Segoe UI', 'Inter', sans-serif"
+        font-size="92"
+        font-weight="800"
+        letter-spacing="-3"
+        fill="#0f172a">kamae-ts</text>
+</svg>

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -6,8 +6,8 @@
     <rect width="240" height="240" rx="36" fill="#3178C6"/>
 
     <g fill="#ffffff">
-      <circle cx="120" cy="40" r="11"/>
-      <rect x="116" y="50" width="8" height="10"/>
+      <ellipse cx="120" cy="42" rx="12" ry="15"/>
+      <rect x="115" y="54" width="10" height="7"/>
       <path d="M80 84 L114 58 L120 86 L126 58 L160 84 L154 132 L86 132 Z"/>
       <path d="M80 84 L50 110 L54 130 L98 116 L100 100 L90 90 Z"/>
       <path d="M160 84 L190 110 L186 130 L142 116 L140 100 L150 90 Z"/>


### PR DESCRIPTION
## Why

`kamae-ts` had no visual identity in its READMEs. A logo at the top of the README gives first-time visitors a recognizable mark to associate with the project, and signals that the project is maintained as a coherent product rather than a loose collection of skills.

## What

- Introduce `docs/assets/logo.svg` as a horizontal lockup: an SVG icon of a martial-arts kamae stance (kiba-dachi guard) on a TypeScript-blue tile, paired with a `kamae-ts` wordmark in the same color as the belt accent (`#0f172a`).
- Render the logo at the top of both `README.md` and `README.ja.md` via a centered `<p align="center">` block, sized at `height="120"` so it stays prominent without overpowering the headline.
- Asset is pure SVG (no raster fallback) so it scales cleanly on GitHub's rendering and stays diff-friendly.

## Test Plan

- [ ] Open the rendered README on GitHub (both English and Japanese) and confirm the logo loads, is centered, and is visually balanced with the headline.
- [ ] Verify the SVG renders correctly at smaller widths (mobile GitHub view).
- [ ] Sanity-check that the relative path `./docs/assets/logo.svg` resolves from both READMEs (they live at the repo root).

---
Generated with Claude Code
