### PR TITLE
fix(docs): exclude ADRs from the site and surface the docs link in READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,6 +2,10 @@
   <img src="./docs/assets/logo.svg" alt="kamae-ts" height="120">
 </p>
 
+<p align="center">
+  <a href="https://iwasa-kosui.github.io/kamae-ts/"><strong>ドキュメント →</strong></a>
+</p>
+
 > English version: [README.md](README.md)
 
 # kamae-ts

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
   <img src="./docs/assets/logo.svg" alt="kamae-ts" height="120">
 </p>
 
+<p align="center">
+  <a href="https://iwasa-kosui.github.io/kamae-ts/"><strong>Documentation →</strong></a>
+</p>
+
 > 日本語版: [README.ja.md](README.ja.md)
 
 # kamae-ts

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -22,3 +22,4 @@ include:
   - ja/validation-libraries
 exclude:
   - superpowers
+  - adr


### PR DESCRIPTION
## Why

Two small but visible issues with the published docs site at https://iwasa-kosui.github.io/kamae-ts/:

1. ADRs are maintainer-facing decision records (e.g. why we picked `microsoft/waza`), but `docs/adr/` was being picked up by just-the-docs since #20 and rendered as a public page alongside the user-facing skill overview and Japanese reading material.
2. The docs site URL itself was buried in a "Documentation" section near the end of both READMEs and described only as a "Japanese reading version", making the path to the site easy to miss for first-time visitors.

## What

- Add `adr` to the `exclude` list in `docs/_config.yml` so Jekyll skips the directory at build time. ADR files stay in the repo and remain reachable from `CLAUDE.md` on GitHub; they just no longer ship to the published site.
- Add a small centered link to the docs site directly under the logo in both `README.md` and `README.ja.md`, so the path to the published documentation is visible from the top of each README.

A separate follow-up PR will introduce a proper English reading version under `docs/en/` to match `docs/ja/`.

## Test Plan

- [ ] After merge, confirm https://iwasa-kosui.github.io/kamae-ts/ no longer surfaces the ADR page in the sidebar or search.
- [ ] Confirm the in-repo link from `CLAUDE.md` to `docs/adr/0001-introduce-waza-for-skill-evals.md` still resolves on GitHub.
- [ ] Open both rendered READMEs on GitHub and confirm the new "Documentation →" link sits centered under the logo and navigates to the docs site.

---
Generated with Claude Code
