### PR TITLE
feat(docs): publish an English reading version under /en/

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -81,7 +81,7 @@ rule のフォーマットと具体例は [`rules/README.md`](./rules/README.md)
 
 ## ドキュメント
 
-日本語の読み物版は [https://iwasa-kosui.github.io/kamae-ts/](https://iwasa-kosui.github.io/kamae-ts/) に公開されている（`/ja/` 配下）。
+読み物版は [https://iwasa-kosui.github.io/kamae-ts/](https://iwasa-kosui.github.io/kamae-ts/) に公開されており、[英語版（`/en/`）](https://iwasa-kosui.github.io/kamae-ts/en/) と [日本語版（`/ja/`）](https://iwasa-kosui.github.io/kamae-ts/ja/) の両方を提供している。
 
 ## 参考記事
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Skill quality is continuously evaluated with [`microsoft/waza`](https://github.c
 
 ## Documentation
 
-A Japanese reading version of the principles is published at [https://iwasa-kosui.github.io/kamae-ts/](https://iwasa-kosui.github.io/kamae-ts/) (see `/ja/`).
+A reading version of the principles is published at [https://iwasa-kosui.github.io/kamae-ts/](https://iwasa-kosui.github.io/kamae-ts/), in both [English (`/en/`)](https://iwasa-kosui.github.io/kamae-ts/en/) and [Japanese (`/ja/`)](https://iwasa-kosui.github.io/kamae-ts/ja/).
 
 ## Reference Articles
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,5 +20,8 @@ include:
   - ja
   - ja/result-libraries
   - ja/validation-libraries
+  - en
+  - en/result-libraries
+  - en/validation-libraries
 exclude:
   - superpowers

--- a/docs/en/boundary-defense.md
+++ b/docs/en/boundary-defense.md
@@ -1,0 +1,289 @@
+---
+title: Boundary Defense
+parent: English
+nav_order: 4
+has_children: true
+---
+
+# Boundary Defense — Detailed Guide
+
+## Understanding the Limits of TypeScript Types
+
+TypeScript types are erased at compile time. No type information survives at runtime, so the correctness of data arriving from outside cannot be guaranteed by types alone.
+
+Structural subtyping means an object with extra properties can be assigned to a type with fewer properties. This can cause unintentional data leaks.
+
+```typescript
+type LogPayload = { id: string; role: string };
+const user = { id: "1", role: "admin", email: "secret@example.com" };
+
+// Passes type checking, but email is included in the log output
+console.log(JSON.stringify(user satisfies LogPayload));
+```
+
+## Schema-Based Validation
+
+At external boundaries (API requests, DB results, environment variables, file reads), parse data using a validation-library schema.
+
+**Detecting the validation library:** Check `dependencies` / `devDependencies` in the project's `package.json` and follow the guide for the matching library. If none is found, ask the user.
+
+- `zod` → [validation-libraries/zod.md](./validation-libraries/zod.md)
+- `valibot` → [validation-libraries/valibot.md](./validation-libraries/valibot.md)
+- `arktype` → [validation-libraries/arktype.md](./validation-libraries/arktype.md)
+
+The examples below use Zod syntax. For equivalent Valibot and ArkType syntax, see the validation-library guides linked above.
+
+```typescript
+import { z } from "zod";
+
+const CreateRequestInput = z.object({
+  passengerId: z.string().uuid(),
+  pickupLocation: z.object({
+    lat: z.number().min(-90).max(90),
+    lng: z.number().min(-180).max(180),
+  }),
+});
+
+type CreateRequestInput = z.infer<typeof CreateRequestInput>;
+```
+
+### Using `safeParse`
+
+`parse` throws an exception. For integration with Railway Oriented Programming, use `safeParse` and convert the result to a Result type.
+
+```typescript
+// Convert the safeParse result to whichever Result-type library the project uses
+const parseInput = (raw: unknown): Result<CreateRequestInput, ValidationError> => {
+  const result = CreateRequestInput.safeParse(raw);
+  if (result.success) return success(result.data);  // ok(), right(), createOk(), etc.
+  return failure({ kind: "ValidationError", issues: result.error.issues });
+};
+```
+
+### Schema Factory: Auto-Converting Validation → Result
+
+The validation → Result conversion above follows the same pattern for every schema. Instead of writing it by hand each time, define one schema factory matched to the project's Result-type library and auto-generate the `parse` function for each schema.
+
+These factories use the [Standard Schema](https://github.com/standard-schema/standard-schema) interface (`schema['~standard'].validate()`), so they work with **any** Standard Schema-compliant library (Zod, Valibot, ArkType, etc.) without modification.
+
+#### For neverthrow
+
+```typescript
+import { ok, err, Result } from "neverthrow";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+
+type ValidationError = Readonly<{
+  kind: "ValidationError";
+  issues: ReadonlyArray<StandardSchemaV1.Issue>;
+}>;
+
+const schemaResult = <T>(schema: StandardSchemaV1<unknown, T>) =>
+  (raw: unknown): Result<T, ValidationError> => {
+    const result = schema["~standard"].validate(raw);
+    if (result instanceof Promise) throw new TypeError("Schema validation must be synchronous");
+    if (result.issues) return err({ kind: "ValidationError", issues: result.issues });
+    return ok(result.value);
+  };
+
+// Usage — works with Zod, Valibot, ArkType, or any Standard Schema-compliant library
+const parseCreateRequestInput = schemaResult(CreateRequestInput);
+const parseRequestId = schemaResult(RequestIdSchema);
+
+// parse: (raw: unknown) => Result<CreateRequestInput, ValidationError>
+const result = parseCreateRequestInput(rawBody);
+```
+
+#### For fp-ts
+
+```typescript
+import * as E from "fp-ts/Either";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+
+type ValidationError = Readonly<{
+  kind: "ValidationError";
+  issues: ReadonlyArray<StandardSchemaV1.Issue>;
+}>;
+
+const schemaEither = <T>(schema: StandardSchemaV1<unknown, T>) =>
+  (raw: unknown): E.Either<ValidationError, T> => {
+    const result = schema["~standard"].validate(raw);
+    if (result instanceof Promise) throw new TypeError("Schema validation must be synchronous");
+    if (result.issues) return E.left({ kind: "ValidationError", issues: result.issues });
+    return E.right(result.value);
+  };
+```
+
+#### For option-t
+
+```typescript
+import { createOk, createErr, type Result } from "option-t/plain_result";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+
+type ValidationError = Readonly<{
+  kind: "ValidationError";
+  issues: ReadonlyArray<StandardSchemaV1.Issue>;
+}>;
+
+const schemaResult = <T>(schema: StandardSchemaV1<unknown, T>) =>
+  (raw: unknown): Result<T, ValidationError> => {
+    const result = schema["~standard"].validate(raw);
+    if (result instanceof Promise) throw new TypeError("Schema validation must be synchronous");
+    if (result.issues) return createErr({ kind: "ValidationError", issues: result.issues });
+    return createOk(result.value);
+  };
+```
+
+#### For byethrow
+
+```typescript
+import { Result } from "@praha/byethrow";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+
+type ValidationError = Readonly<{
+  kind: "ValidationError";
+  issues: ReadonlyArray<StandardSchemaV1.Issue>;
+}>;
+
+const schemaResult = <T>(schema: StandardSchemaV1<unknown, T>) =>
+  (raw: unknown): Result.Result<T, ValidationError> => {
+    const result = schema["~standard"].validate(raw);
+    if (result instanceof Promise) throw new TypeError("Schema validation must be synchronous");
+    if (result.issues) return Result.fail({ kind: "ValidationError", issues: result.issues });
+    return Result.succeed(result.value);
+  };
+```
+
+#### Guidelines
+
+- Do not hand-write the validation → Result conversion for each schema. Define one factory function and reuse it throughout the project.
+- The factory's return type should be unified to the Result-type library the project uses.
+- Because the factory uses Standard Schema, the same factory works with any Standard Schema-compliant validation library (Zod, Valibot, ArkType).
+- Combine with the Companion Object pattern to expose the schema definition and `parse` function together:
+
+```typescript
+// Works with any Standard Schema-compliant validation library
+const RequestId = {
+  schema: RequestIdSchema,
+  parse: schemaResult(RequestIdSchema),
+} as const;
+
+// At the call site
+const id = RequestId.parse(raw); // Result<RequestId, ValidationError>
+```
+
+## Banning Type Assertions (`as`)
+
+`as` bypasses type checking. Use schema validation for external data; trust type inference for internal data.
+
+```typescript
+// Bad
+const user = data as User;
+
+// Good
+const user = UserSchema.parse(data);
+```
+
+For Branded Types, using the validation library's branding feature eliminates the need for `as`. See the [validation-library guides](./validation-libraries/) for Valibot/ArkType Branded Types syntax.
+
+```typescript
+// ❌ Manual brand + as cast
+type ItemId = string & { readonly __brand: unique symbol };
+const ItemIdSchema = z.string().regex(/^item-\d+$/);
+const parse = (raw: string): ItemId => ItemIdSchema.parse(raw) as ItemId;
+
+// ✅ z.brand() — no as needed (Zod example)
+export const ItemIdBrand = Symbol();
+const ItemIdSchema = z.string().regex(/^item-\d+$/).brand<typeof ItemIdBrand>();
+type ItemId = z.infer<typeof ItemIdSchema>;
+const parse = (raw: string): ItemId => ItemIdSchema.parse(raw); // already typed as ItemId
+```
+
+In projects that do not use a validation library, `as` is acceptable inside the constructor function for Branded Types.
+
+```typescript
+const UserId = {
+  of: (value: string): UserId => value as UserId, // acceptable only when not using Zod
+};
+```
+
+## PII Defense with `Sensitive<T>`
+
+### The Problem
+
+TypeScript types are erased at runtime, so marking a field as PII in the type system does not prevent it from leaking through `JSON.stringify` or `console.log`. With Branded Types, the brand is also lost on variable assignment.
+
+### Solution: Closure-Based Wrapper
+
+Encapsulate the value in a function closure and auto-mask it during serialization.
+
+```typescript
+type Sensitive<T> = Readonly<{
+  unwrap: () => T;
+  toJSON: () => string;
+  toString: () => string;
+}>;
+
+const Sensitive = {
+  of: <T>(value: T): Sensitive<T> => ({
+    unwrap: () => value,
+    toJSON: () => "[REDACTED]",
+    toString: () => "[REDACTED]",
+    [Symbol.for("nodejs.util.inspect.custom")]: () => "[REDACTED]",
+  }),
+} as const;
+```
+
+### Integration with Validation Libraries
+
+Wrap values in `Sensitive` automatically during parsing. The example below uses Zod. For equivalent Valibot and ArkType syntax, see the [validation-library guides](./validation-libraries/).
+
+```typescript
+const sensitiveString = z.string().transform(Sensitive.of);
+
+const PatientSchema = z.object({
+  id: z.string().uuid(),
+  name: sensitiveString,
+  email: sensitiveString,
+  diagnosis: sensitiveString,
+  role: z.string(), // not PII
+});
+
+const patient = PatientSchema.parse(rawData);
+console.log(JSON.stringify(patient));
+// {"id":"...","name":"[REDACTED]","email":"[REDACTED]","diagnosis":"[REDACTED]","role":"doctor"}
+```
+
+### Defense in Depth: Pino Redaction
+
+As a safeguard against missed `Sensitive` wrapping, also configure redaction at the logger level.
+
+```typescript
+import pino from "pino";
+
+const logger = pino({
+  redact: {
+    paths: ["email", "*.email", "password", "*.password", "name", "*.name"],
+    censor: "[REDACTED]",
+  },
+});
+```
+
+## Avoid Over-Defending Inside the Domain
+
+Data that has already been validated at an external boundary does not need to be re-validated inside the domain layer. Trust the types.
+
+```typescript
+// Bad: redundant checks in the domain layer
+const assignDriver = (waiting: Waiting, driverId: DriverId): EnRoute => {
+  if (waiting.kind !== "Waiting") throw new Error("Invalid state"); // the type already guarantees this
+  if (!driverId) throw new Error("Missing driverId"); // the type already guarantees this
+  return { kind: "EnRoute", passengerId: waiting.passengerId, driverId };
+};
+
+// Good: trust the types
+const assignDriver = (waiting: Waiting, driverId: DriverId): EnRoute => ({
+  kind: "EnRoute",
+  passengerId: waiting.passengerId,
+  driverId,
+});
+```

--- a/docs/en/code-review.md
+++ b/docs/en/code-review.md
@@ -1,0 +1,212 @@
+---
+title: Code Review
+description: An adversarial review guide for server-side TypeScript code grounded in the kamae-ts principles
+parent: English
+nav_order: 7
+---
+
+# Functional TypeScript Code Review
+
+A guide for reviewing server-side TypeScript code against the kamae-ts principles (see [index](./index.md)). Each checklist item maps one-to-one to a chapter of the principles.
+
+> This guide is a human-readable version of the checklist used internally by the `kamae-review` skill in the [kamae-ts plugin](https://github.com/iwasa-kosui/kamae-ts). Use it as a reference when reviewing manually without a coding agent.
+
+## Review Procedure
+
+1. **Read the principle knowledge base first.** Before looking at code, read the following so you can cite canonical principles in your findings:
+   - [index.md](./index.md) — principle index
+   - [error-handling.md](./error-handling.md)
+   - [boundary-defense.md](./boundary-defense.md)
+   - [state-modeling.md](./state-modeling.md)
+   - The validation-library guide matching the project's `package.json` ([validation-libraries/](./validation-libraries/) — `zod.md` / `valibot.md` / `arktype.md`)
+   - The Result-library guide matching the project's `package.json` ([result-libraries/](./result-libraries/) — `neverthrow.md` / `byethrow.md` / `fp-ts.md` / `option-t.md`)
+2. Read the files under review.
+3. Scan through the checklist items below in principle order (matching the chapter structure of [index.md](./index.md)).
+4. When you find a violation, report it with the principle, the reason it matters, and a suggested fix.
+5. When something is not a violation but could be improved, present it as a suggestion.
+
+## Checklist
+
+The checklist directly mirrors the structure of [index.md](./index.md). Each item links back to the canonical chapter.
+
+### 1. Type-Driven Domain Modeling
+
+#### 1.1 Domain state modeled as a Discriminated Union
+
+Reference: [`./index.md` §1 "Express domain state with Discriminated Unions"](./index.md)
+
+Signal: a single type with many optional properties and a `string` status field (e.g. `{ state: string; driverId?: string; startTime?: Date }`). Suggest splitting into per-state types combined into a union, making state-specific properties required.
+
+#### 1.2 Discriminant unified as `kind`
+
+Reference: [`./index.md` §1 "Use `kind` as the unifying discriminant"](./index.md)
+
+Signal: a discriminant named `type`, `status`, `state`, `_tag`, or anything other than `kind`. Suggest renaming to `kind` for codebase consistency.
+
+#### 1.3 No use of `class` for domain models
+
+Reference: [`./index.md` §1 "Express domain state with Discriminated Unions"](./index.md) and the Companion Object pattern.
+
+When `class` is used to define a domain entity or value object, suggest migrating to a Discriminated Union + Companion Object pattern. Class inheritance required by an external library is a justified deviation.
+
+#### 1.4 Companion Object pattern followed
+
+Reference: [`./index.md` §1 "Companion Object pattern"](./index.md)
+
+Verify:
+- Operations related to a type are consolidated in a `const` with the same name as the type.
+- A Branded Type's validation schema is exposed as a `.schema` property on the companion object, not as a standalone `XxxSchema` export.
+- Domain logic that belongs on the companion object is not scattered as free-standing functions like `xxxAssignDriver`.
+
+#### 1.5 No `interface` for domain types
+
+Reference: [`./index.md` §1 "Use `type`, not `interface`"](./index.md)
+
+Declaration merging can silently alter a type's shape. Define domain types with `type`. `interface` is only acceptable for library type augmentation.
+
+#### 1.6 No method notation in type definitions
+
+Reference: [`./index.md` §1 "Use function-property notation, not method notation"](./index.md)
+
+Method notation (`save(task: Task): Promise<void>`) makes parameters bivariant, allowing a narrower implementation (`save(task: DoingTask): …`) to pass type-checking at the injection site. Suggest switching to function-property notation (`save: (task: Task) => Promise<void>`).
+
+#### 1.7 Branded Types applied to semantically distinct primitives
+
+Reference: [`./index.md` §1 "Use Branded Types to distinguish meaning"](./index.md). Also see the project's validation-library guide ([`./validation-libraries/`](./validation-libraries/)).
+
+Signal: IDs or semantically distinct values (`UserId`, `OrderId`, `Email`, monetary amounts, etc.) represented as plain `string` / `number`. If a validation library is present, verify that its branding feature is used (no `as` cast needed); otherwise confirm the `unique symbol` pattern is in place.
+
+#### 1.8 Domain objects wrapped in `Readonly<>`
+
+Reference: [`./index.md` §1 "Use `Readonly<>` to guarantee immutability"](./index.md)
+
+Signal: domain object type definitions not protected by `Readonly<…>` (or per-property `readonly`). State changes should be expressed by constructing new objects.
+
+#### 1.9 One-concept-per-file layout
+
+Reference: [`./index.md` §1 "File layout: one concept per file"](./index.md)
+
+Signal: catch-all files such as `types.ts`, `models.ts`, or `domain.ts` that aggregate many domain types, especially when companion objects live in separate files. Barrel files (`index.ts`) should contain re-exports only.
+
+### 2. State Transitions via Pure Functions
+
+Reference: [`./index.md` §2](./index.md) and [`./state-modeling.md`](./state-modeling.md)
+
+#### 2.1 Transition functions constrain the source state via argument types
+
+Signal: a transition function's argument type is the full union (`TaxiRequest`) rather than an individual state (`Waiting`). Accepting a wide type allows calls from invalid source states.
+
+#### 2.2 `assertNever` present in `switch` over a Discriminated Union
+
+Reference: [`./index.md` §2 "Exhaustiveness check"](./index.md)
+
+Signal: a `switch` branching on `kind` without `default: return assertNever(x)`. Adding a new variant will not produce a compile error.
+
+### 3. Error Handling — Railway Oriented Programming
+
+Reference: [`./index.md` §3](./index.md), [`./error-handling.md`](./error-handling.md), and the project's Result-library guide ([`./result-libraries/`](./result-libraries/)).
+
+#### 3.1 No `throw` in the domain layer
+
+Signal: `throw` inside an entity, value object, or use case. Suggest converting to a `Result` type. Acceptable exceptions: `throw` inside `assertNever` (unreachable), and unexpected infrastructure failures in the infrastructure layer.
+
+#### 3.2 Error types defined as Discriminated Unions
+
+Signal: `Error` subclasses, free-form `string` error codes, or `Result<T, string>`. Suggest a Discriminated Union (`{ kind: "DriverNotAvailable"; driverId } | { kind: "RequestAlreadyAssigned" }`) so callers can handle errors exhaustively.
+
+#### 3.3 Result chains used for composition (no premature unwrap)
+
+Verify that the project's Result-library API (`.map`, `.andThen`, `Result.do`, etc.) is used for chained composition. If the code immediately unwraps into `if/else`, cite the relevant guide under `./result-libraries/` and suggest an appropriate combinator.
+
+### 4. Boundary Defense
+
+Reference: [`./index.md` §4](./index.md), [`./boundary-defense.md`](./boundary-defense.md), and the project's validation-library guide ([`./validation-libraries/`](./validation-libraries/)).
+
+#### 4.1 Schema validation at every external boundary
+
+Signal: API handlers, DB result mappings, queue/message handlers, file/config reads, or environment-variable reads where raw data is treated as a domain type without being parsed through a validation library (Zod / Valibot / ArkType).
+
+#### 4.2 No `as` type assertions
+
+Reference: [`./index.md` §4 "Do not use type assertions (`as`)"](./index.md)
+
+Enumerate every `as` and verify it falls into one of:
+- External data: should be replaced with schema parsing.
+- `as` inside a Branded Type constructor: acceptable only when not using a validation library (the `unique symbol` pattern).
+- Internal data: should be resolvable via type inference. If not, the type design is likely wrong.
+
+#### 4.3 PII fields wrapped in `Sensitive<T>`
+
+Reference: [`./index.md` §4 "PII defense"](./index.md), [`./boundary-defense.md`](./boundary-defense.md)
+
+Signal: fields that may contain personal information (name, email address, phone number, address, various IDs, payment information, health/diagnostic information, IP address, etc.) represented as plain `string` / `number`. Pay particular attention to objects that may appear in logs or error messages. Also check that the validation schema automatically wraps PII fields with `Sensitive.of`.
+
+### 5. Declarative Style
+
+Reference: [`./index.md` §5](./index.md), [`./state-modeling.md`](./state-modeling.md)
+
+#### 5.1 Array operations written declaratively
+
+Signal: transformations expressible with `filter` / `map` / `reduce` being built imperatively with `for` / `for…of` loops. Suggest defining predicate functions on the companion object and writing `tasks.filter(Task.isActive)`.
+
+#### 5.2 Domain events published as immutable records
+
+Signal: state-mutation code directly mutating a shared event log, or domain events not being published where the state-modeling guide requires them. Events should be recorded as `Readonly<{ eventId; eventAt; eventName; payload; aggregateId }>`, separated from the repository.
+
+### 6. Test Data
+
+Reference: [`./index.md` §6](./index.md)
+
+#### 6.1 Fixtures defined with `as const satisfies Type`
+
+Signal: test fixtures typed with `: Type =` or `as Type`, causing discriminant literal types to widen to `string`. Suggest `as const satisfies Type` to preserve the `kind` literal type.
+
+## How to Write Findings
+
+Each finding should include:
+
+1. **What is wrong**: the specific code location (`path:line`).
+2. **Why it matters**: the principle (with a reference link to `./...`) and the risk introduced by the violation.
+3. **How to fix it**: a code example showing the suggested fix.
+
+```
+### Method notation used
+
+`src/repository/task-repository.ts:15`
+
+`save(task: Task): Promise<void>` uses method notation.
+Per [`./index.md` §1 "Use function-property notation"](./index.md),
+method notation makes parameters bivariant, so a narrower implementation
+`save(task: DoingTask): Promise<void>` would pass type-checking at the injection site.
+
+Suggested fix:
+\`\`\`typescript
+type TaskRepository = {
+  save: (task: Task) => Promise<void>;
+};
+\`\`\`
+```
+
+## Severity
+
+| Severity | Item | Reason |
+|----------|------|--------|
+| [High] | `as` type assertions (4.2) | Direct cause of runtime errors |
+| [High] | Unprotected PII (4.3) | Compliance violation risk |
+| [High] | Missing schema validation at external boundaries (4.1) | Direct cause of runtime errors |
+| [High] | Missing Branded Types for semantically distinct primitives (1.7) | Mixed-up IDs surface at runtime |
+| [Medium] | Use of `class` (1.3) | Degrades type safety during extension |
+| [Medium] | State modeled with optional properties (1.1) | Invalid states become representable |
+| [Medium] | `throw` in the domain layer (3.1) | Inconsistent error handling |
+| [Medium] | Error type not a Discriminated Union (3.2) | Callers cannot handle errors exhaustively |
+| [Medium] | Missing `assertNever` (2.2) | New variants go undetected at compile time |
+| [Medium] | Transition function accepts the full union type (2.1) | Invalid transitions compile without error |
+| [Medium] | Catch-all type files (1.9) | Circular dependencies; type/behavior separation |
+| [Medium] | Companion Object pattern violated; schema exported standalone (1.4) | Leaks implementation details |
+| [Low] | Method notation (1.6) | Only problematic under specific conditions |
+| [Low] | `interface` for domain types (1.5) | Declaration-merging accidents are rare |
+| [Low] | Domain types missing `Readonly<>` (1.8) | Mutations are often caught in review |
+| [Low] | Discriminant is not `kind` (1.2) | Style inconsistency rather than a bug |
+| [Low] | Imperative array loops (5.1) | Readability, not correctness |
+| [Low] | Domain events not published (5.2) | Depends on whether event sourcing is adopted |
+| [Low] | Fixtures missing `as const satisfies` (6.1) | Typically caught by tests in practice |

--- a/docs/en/declarative-style.md
+++ b/docs/en/declarative-style.md
@@ -1,0 +1,44 @@
+---
+title: Declarative Style
+parent: English
+nav_order: 5
+---
+
+# Declarative Style — Detailed Guide
+
+## Array Operations
+
+Transform arrays declaratively with `filter` / `map` / `reduce`. Define predicate functions on the Companion Object.
+
+```typescript
+type Task = ActiveTask | CompletedTask;
+
+const Task = {
+  isActive: (task: Task): task is ActiveTask => task.kind === "Active",
+} as const;
+
+// Declarative: intent is immediately clear
+const activeTasks = tasks.filter(Task.isActive);
+
+// Imperative: you have to read the loop body to understand what it does
+const activeTasks: ActiveTask[] = [];
+for (const task of tasks) {
+  if (task.kind === "Active") activeTasks.push(task);
+}
+```
+
+## Domain Events
+
+Produce domain events that accompany state changes as immutable records, separate from the repository.
+
+```typescript
+type DomainEvent = Readonly<{
+  eventId: string;
+  eventAt: Date;
+  eventName: string;
+  payload: unknown;
+  aggregateId: string;
+}>;
+```
+
+For the detailed design of domain events — including who is responsible for constructing them and how they integrate with use cases — see [state-modeling.md](./state-modeling.md).

--- a/docs/en/domain-modeling.md
+++ b/docs/en/domain-modeling.md
@@ -1,0 +1,181 @@
+---
+title: Type-Driven Domain Modeling
+parent: English
+nav_order: 1
+---
+
+# Type-Driven Domain Modeling — Detailed Guide
+
+## Expressing State with Discriminated Unions
+
+Model domain entity state with Discriminated Unions, not classes. Define each state as a distinct type and make state-specific properties required.
+
+```typescript
+// Good: each state is an independent type; state-specific properties are required
+type Waiting = Readonly<{
+  kind: "Waiting";
+  passengerId: PassengerId;
+}>;
+
+type EnRoute = Readonly<{
+  kind: "EnRoute";
+  passengerId: PassengerId;
+  driverId: DriverId;
+}>;
+
+type TaxiRequest = Waiting | EnRoute | InTrip | Completed | Cancelled;
+```
+
+```typescript
+// Bad: all states collapsed into one type via optional properties
+type TaxiRequest = {
+  state: string;
+  passengerId: string;
+  driverId?: string;    // unclear which states this exists in
+  startTime?: Date;     // null checks required everywhere
+  endTime?: Date;
+};
+```
+
+**Why:** Optional properties give no compile-time guarantee about which properties exist in which state. With a Discriminated Union, narrowing on `kind` in a switch statement gives you safe access to state-specific properties immediately.
+
+## Use `kind` as the Discriminant
+
+Use `kind` as the discriminant property name throughout the project. Mixing `type`, `status`, and `state` as discriminant names breaks codebase consistency.
+
+## Companion Object Pattern
+
+Group a type and its related functions under the same name as a `const` object. Validation schemas for Branded Types should be exposed as a `schema` property on the companion object rather than as standalone exports.
+
+```typescript
+// Bad: schema as a standalone export — leaks implementation details
+export const ItemIdBrand = Symbol();
+export const ItemIdSchema = z.string().regex(/^item-\d+$/).brand<typeof ItemIdBrand>();
+
+// Good: companion object owns the schema
+const ItemIdBrand = Symbol();
+const ItemIdSchema = z.string().regex(/^item-\d+$/).brand<typeof ItemIdBrand>();
+export type ItemId = z.infer<typeof ItemIdSchema>;
+
+export const ItemId = {
+  schema: ItemIdSchema,
+  parse: (raw: string) => ItemIdSchema.safeParse(raw),
+} as const;
+```
+
+```typescript
+type TaxiRequest = Waiting | EnRoute | InTrip | Completed | Cancelled;
+
+const TaxiRequest = {
+  assignDriver: (waiting: Waiting, driverId: DriverId): EnRoute => ({
+    kind: "EnRoute",
+    passengerId: waiting.passengerId,
+    driverId,
+  }),
+
+  startTrip: (enRoute: EnRoute, startTime: Date): InTrip => ({
+    kind: "InTrip",
+    passengerId: enRoute.passengerId,
+    driverId: enRoute.driverId,
+    startTime,
+  }),
+
+  isActive: (request: TaxiRequest): request is Waiting | EnRoute | InTrip =>
+    request.kind !== "Completed" && request.kind !== "Cancelled",
+} as const;
+```
+
+## Use `type`, Not `interface`
+
+Define domain types with `type`. The declaration-merging behavior of `interface` means that declaring an interface with the same name in another file silently changes the shape of the type.
+
+```typescript
+// Good
+type User = Readonly<{
+  id: UserId;
+  name: string;
+}>;
+
+// Bad: if another file declares `interface User { hashedPassword?: string }`,
+// the type changes without any warning
+interface User {
+  id: string;
+  name: string;
+}
+```
+
+## Function-Property Notation, Not Method Notation
+
+Write functions inside type definitions using function-property notation rather than method notation. Method notation makes parameter types bivariant, which breaks type safety.
+
+```typescript
+// Good: function-property notation — parameters are contravariant
+type TaskRepository = {
+  save: (task: Task) => Promise<void>;
+  findById: (id: TaskId) => Promise<Task | undefined>;
+};
+
+// Bad: method notation — parameters become bivariant, so a narrower
+// implementation like save(task: DoingTask) passes the type checker
+type TaskRepository = {
+  save(task: Task): Promise<void>;
+  findById(id: TaskId): Promise<Task | undefined>;
+};
+```
+
+## Branded Types for Semantic Distinction
+
+TypeScript's structural subtyping makes two `string` values mutually assignable. Apply Branded Types to IDs and values that carry different meanings.
+
+**Detecting your validation library:** Check `dependencies` / `devDependencies` in the project's `package.json` and follow the guide for whichever library is present. If none is found, ask the user.
+
+- `zod` → [validation-libraries/zod.md](./validation-libraries/zod.md)
+- `valibot` → [validation-libraries/valibot.md](./validation-libraries/valibot.md)
+- `arktype` → [validation-libraries/arktype.md](./validation-libraries/arktype.md)
+
+When using a validation library, define Branded Types with its branding feature. The schema's output type is automatically branded, so no `as` cast is needed. Zod example:
+
+```typescript
+import { z } from "zod";
+
+export const UserIdBrand = Symbol();
+const UserIdSchema = z.string().uuid().brand<typeof UserIdBrand>();
+type UserId = z.infer<typeof UserIdSchema>;
+
+export const ProductIdBrand = Symbol();
+const ProductIdSchema = z.string().uuid().brand<typeof ProductIdBrand>();
+type ProductId = z.infer<typeof ProductIdSchema>;
+
+// safeParse().data is already branded — no `as` needed
+```
+
+For projects that do not use a validation library, use the `unique symbol` pattern:
+
+```typescript
+export const UserIdBrand = Symbol();
+type UserId = string & { readonly [typeof UserIdBrand]: never };
+
+export const ProductIdBrand = Symbol();
+type ProductId = string & { readonly [typeof ProductIdBrand]: never };
+```
+
+## `Readonly<>` for Immutability
+
+Define domain objects with `Readonly<>` to prevent property reassignment. Express state changes by constructing a new object.
+
+## File Layout: One Concept per File
+
+Place each domain concept (type + companion object) in its own dedicated file. Catch-all files like `types.ts` or `models.ts` are not allowed — they separate types from behavior and become a source of circular dependencies.
+
+```
+// Bad: types aggregated in types.ts, companions in separate files
+// types.ts — ItemId, ItemType, Status, Priority, Item, Config, ...
+// item-id.ts — ItemId companion object (imports types from types.ts)
+
+// Good: one file per concept
+// item-id.ts — type ItemId + const ItemId (companion)
+// item-type.ts — type ItemType + const ItemType (companion)
+// status.ts — type Status + const Status (companion)
+```
+
+Barrel files (`index.ts`) are for re-exports only; do not define types or functions directly inside them.

--- a/docs/en/error-handling.md
+++ b/docs/en/error-handling.md
@@ -1,0 +1,87 @@
+---
+title: Error Handling
+parent: English
+nav_order: 3
+has_children: true
+---
+
+# Error Handling — Detailed Guide
+
+## Railway Oriented Programming
+
+Use Result types to represent success and failure as values. Do not throw exceptions in the domain layer. For library-specific APIs, refer to the relevant guide under [result-libraries/](./result-libraries/).
+
+## Designing Error Types
+
+Define error types as Discriminated Unions so callers can handle them exhaustively.
+
+```typescript
+type AssignDriverError =
+  | Readonly<{ kind: "RequestNotFound"; requestId: RequestId }>
+  | Readonly<{ kind: "InvalidState"; currentKind: string; expectedKind: "Waiting" }>
+  | Readonly<{ kind: "DriverNotAvailable"; driverId: DriverId }>;
+```
+
+### Error Type Granularity
+
+Each use case should return an error type specific to that use case. Stuffing everything into a shared `AppError` type makes it impossible for callers to determine from the types alone which errors can actually occur.
+
+```typescript
+// Good: use-case-specific error types
+type AssignDriverError = RequestNotFoundError | InvalidStateError | DriverNotAvailableError;
+type StartTripError = RequestNotFoundError | InvalidStateError;
+
+// Bad: cramming all errors into one type
+type AppError = RequestNotFoundError | InvalidStateError | DriverNotAvailableError | ...;
+```
+
+## Composing Operations
+
+Each step returns a Result type, and if an error occurs at any step the remaining steps are skipped. The composition API differs by library (`.andThen()` in neverthrow/byethrow, `pipe` + `chain` in fp-ts, `flatMapForResult` in option-t).
+
+### Helper Functions
+
+Extract common validations into small functions and use them as individual composition steps.
+
+```typescript
+// Helper return type is Result. The specific API (ok/err, right/left, etc.) depends on the library.
+const ensureFound = <T>(id: RequestId) => (
+  value: T | undefined,
+): Result<T, RequestNotFoundError> =>
+  value !== undefined
+    ? success(value)   // ok(), right(), createOk(), etc.
+    : failure({ kind: "RequestNotFound", requestId: id });
+
+const ensureWaiting = (
+  request: TaxiRequest,
+): Result<Waiting, InvalidStateError> =>
+  request.kind === "Waiting"
+    ? success(request)
+    : failure({ kind: "InvalidState", currentKind: request.kind, expectedKind: "Waiting" });
+```
+
+## Translating Errors in the Controller Layer
+
+Mapping domain errors to HTTP responses is the responsibility of the controller layer. Determine the status code based on the `kind` of the domain error.
+
+```typescript
+const toHttpResponse = (error: AssignDriverError): Response => {
+  switch (error.kind) {
+    case "RequestNotFound":
+      return notFound(`Request ${error.requestId} not found`);
+    case "InvalidState":
+      return conflict(`Expected ${error.expectedKind}, got ${error.currentKind}`);
+    case "DriverNotAvailable":
+      return unprocessableEntity(`Driver ${error.driverId} is not available`);
+    default:
+      return assertNever(error);
+  }
+};
+```
+
+## When Exceptions Are Appropriate
+
+The domain layer does not throw exceptions, but the following are legitimate uses:
+
+- `assertNever`: detecting unreachable code (programming bugs)
+- Unexpected infrastructure failures (e.g. dropped DB connections) — delegate these to the framework's error handler

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,0 +1,67 @@
+---
+title: English
+description: A reading version of the kamae-ts principles for designing and implementing robust server-side TypeScript applications
+nav_order: 2
+has_children: true
+permalink: /en/
+---
+
+# kamae-ts — Functional Domain Modeling
+
+A reading version of the principles to follow when modeling domains in server-side TypeScript. Instead of class-based OOP, we lean on the TypeScript type system and a functional approach.
+
+This is a human-oriented reorganization of the knowledge base used by the coding-agent skills shipped in the [kamae-ts plugin](https://github.com/iwasa-kosui/kamae-ts).
+
+## 1. Type-Driven Domain Modeling
+
+Express domain state with Discriminated Unions and use `kind` as the unifying discriminant. Prefer `type` over `interface`, the Companion Object pattern, Branded Types, `Readonly<>`, function-property notation, and a one-concept-per-file layout.
+
+→ [domain-modeling.md](./domain-modeling.md)
+
+## 2. State Transitions via Pure Functions
+
+Express state transitions with pure functions: argument types constrain valid source states, return types declare the target state, and invalid transitions become compile errors. Use `assertNever` to enforce exhaustiveness.
+
+→ [state-modeling.md](./state-modeling.md)
+
+## 3. Error Handling — Railway Oriented Programming
+
+Do not throw exceptions; treat errors as values via Result types. Define error types as Discriminated Unions so callers can handle them exhaustively.
+
+Library guides: [neverthrow](./result-libraries/neverthrow.md) / [byethrow](./result-libraries/byethrow.md) / [fp-ts](./result-libraries/fp-ts.md) / [option-t](./result-libraries/option-t.md)
+
+→ [error-handling.md](./error-handling.md)
+
+## 4. Boundary Defense
+
+Validate external inputs (API requests, DB results, file reads) at runtime with a validation-library schema. Trust types inside the domain layer. Do not use type assertions (`as`). Wrap PII fields in a `Sensitive<T>` wrapper.
+
+Library guides: [zod](./validation-libraries/zod.md) / [valibot](./validation-libraries/valibot.md) / [arktype](./validation-libraries/arktype.md)
+
+→ [boundary-defense.md](./boundary-defense.md)
+
+## 5. Declarative Style
+
+Transform arrays declaratively with `filter` / `map` / `reduce`, using predicate functions defined on the Companion Object. Model domain events as immutable records.
+
+→ [declarative-style.md](./declarative-style.md)
+
+## 6. Test Data
+
+Define test data with `as const satisfies Type` to preserve discriminant literal types and prevent widening.
+
+→ [test-data.md](./test-data.md)
+
+## Code Review
+
+For an adversarial code-review guide grounded in these principles, see [code-review.md](./code-review.md).
+
+## Applying the Principles
+
+These are recommendations, not strict rules. Use judgment based on context, but when you depart from a principle, document the reason in a comment.
+
+Typical justified deviations:
+
+- An external library requires class inheritance.
+- Performance requirements make immutable-data construction costs problematic.
+- A team has agreed on a different pattern.

--- a/docs/en/result-libraries/byethrow.md
+++ b/docs/en/result-libraries/byethrow.md
@@ -1,0 +1,182 @@
+---
+title: byethrow
+parent: Error Handling
+grand_parent: English
+nav_order: 2
+---
+
+# @praha/byethrow
+
+## Core API
+
+```typescript
+import { Result } from "@praha/byethrow";
+```
+
+| Function / Type | Description |
+|-----------------|-------------|
+| `Result.Result<T, E>` | Result type (`Success<T> \| Failure<E>` discriminated union, plain object) |
+| `Result.ResultAsync<T, E>` | Type alias for `Promise<Result<T, E>>` |
+| `Result.succeed(value)` | Constructs a success value (`{ type: "Success", value }`) |
+| `Result.fail(error)` | Constructs a failure value (`{ type: "Failure", error }`) |
+| `Result.do()` | Produces `Success<{}>`. Starting point for incrementally building an object with `bind` |
+| `Result.bind(name, fn)` | Adds the result of `fn` to the success object under `name` (`andThen` + merge) |
+| `Result.andThrough(fn)` | Runs a side effect; on success, returns the original value unchanged |
+| `Result.orThrough(fn)` | Runs a side effect on the error path; on failure, returns the original error unchanged |
+
+Key differences from neverthrow:
+
+- Plain objects instead of classes (discriminant is the `type` field)
+- Composition via `Result.pipe` + curried functions instead of method chaining
+- `andThrough` / `orThrough` for side effects that preserve the current value
+
+## Composition with pipe
+
+```typescript
+Result.pipe(
+  result,
+  Result.map((value) => transform(value)),         // Transform the success value
+  Result.mapError((error) => transformErr(error)),  // Transform the error value
+  Result.andThen((value) => nextResult(value)),     // Chain to the next Result (flatMap)
+  Result.andThrough((value) => sideEffect(value)),  // Run a side effect; preserve the original value on success
+  Result.orElse((error) => recover(error)),         // Recover from an error
+);
+
+// Async: passing a function that returns Promise<Result> to andThen/andThrough
+// automatically promotes the entire pipe to a Promise (ResultMaybeAsync)
+Result.pipe(
+  result,
+  Result.andThen((value) => fetchSomething(value)), // Returning ResultAsync is fine
+  Result.andThrough((value) => saveToDb(value)),    // Side effects also support async
+);
+
+// do + bind: incrementally build an object
+Result.pipe(
+  Result.do(),                                       // Start from Success<{}>
+  Result.bind("user", () => findUser(userId)),       // { user: User }
+  Result.bind("order", ({ user }) => findOrder(user)), // { user: User, order: Order }
+  Result.andThrough(({ order }) => validate(order)), // Validation (value is preserved)
+  Result.map(({ user, order }) => buildResponse(user, order)),
+);
+
+// Branch with a type guard
+if (Result.isSuccess(result)) {
+  console.log(result.value);
+} else {
+  console.log(result.error);
+}
+```
+
+## Example: State-Transition Pipeline
+
+Following Railway Oriented Programming principles, extract each step into an independent function and compose them in the use case using `Result.pipe`. 
+
+For the design of `RequestResolver` / `RequestStore` and how to persist state and domain events in a single transaction, see [state-modeling.md#domain-events](../state-modeling.md#ドメインイベント).
+
+```typescript
+import { Result } from "@praha/byethrow";
+
+// --- Branded Types ---
+
+declare const RequestIdBrand: unique symbol;
+type RequestId = string & { readonly [RequestIdBrand]: never };
+
+declare const DriverIdBrand: unique symbol;
+type DriverId = string & { readonly [DriverIdBrand]: never };
+
+declare const PassengerIdBrand: unique symbol;
+type PassengerId = string & { readonly [PassengerIdBrand]: never };
+
+// --- State Types ---
+
+type Waiting = Readonly<{
+  kind: "Waiting";
+  requestId: RequestId;
+  passengerId: PassengerId;
+}>;
+
+type EnRoute = Readonly<{
+  kind: "EnRoute";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  driverId: DriverId;
+}>;
+
+// --- Repository Types ---
+
+type RequestResolver = Readonly<{
+  findById: (id: RequestId) => Result.ResultAsync<Waiting | undefined, RepositoryError>;
+}>;
+
+type RequestStore = Readonly<{
+  save: (state: EnRoute) => Result.ResultAsync<void, RepositoryError>;
+}>;
+
+// --- Error Types ---
+
+type AssignDriverError =
+  | Readonly<{ kind: "RequestNotFound"; requestId: RequestId }>
+  | Readonly<{ kind: "DriverNotAvailable"; driverId: DriverId }>
+  | Readonly<{ kind: "RepositoryError"; cause: unknown }>;
+
+type RepositoryError = Readonly<{ kind: "RepositoryError"; cause: unknown }>;
+
+// --- Domain Functions ---
+
+const findWaitingRequest =
+  (requestResolver: RequestResolver) =>
+  (requestId: RequestId): Result.ResultAsync<Waiting | undefined, AssignDriverError> =>
+    requestResolver.findById(requestId);
+
+const ensureExists =
+  (requestId: RequestId) =>
+  (request: Waiting | undefined): Result.Result<Waiting, AssignDriverError> =>
+    request !== undefined
+      ? Result.succeed(request)
+      : Result.fail({ kind: "RequestNotFound", requestId });
+
+const ensureDriverAvailable =
+  (driverId: DriverId, isAvailable: boolean) =>
+  (): Result.Result<DriverId, AssignDriverError> =>
+    isAvailable
+      ? Result.succeed(driverId)
+      : Result.fail({ kind: "DriverNotAvailable", driverId });
+
+const transitionToEnRoute = (ctx: {
+  waiting: Waiting;
+  driverId: DriverId;
+}): EnRoute => ({
+  kind: "EnRoute",
+  requestId: ctx.waiting.requestId,
+  passengerId: ctx.waiting.passengerId,
+  driverId: ctx.driverId,
+});
+
+// --- Use Case (full pipeline composition via do + bind) ---
+
+const assignDriverUseCase =
+  (requestResolver: RequestResolver, requestStore: RequestStore) =>
+  (
+    requestId: RequestId,
+    driverId: DriverId,
+    isDriverAvailable: boolean,
+  ): Result.ResultAsync<EnRoute, AssignDriverError> =>
+    Result.pipe(
+      Result.do(),
+      // 1. Fetch request → verify existence
+      Result.bind("waiting", () =>
+        Result.pipe(
+          findWaitingRequest(requestResolver)(requestId),
+          Result.andThen(ensureExists(requestId)),
+        ),
+      ),
+      // 2. Check driver availability
+      Result.bind("driverId", () =>
+        ensureDriverAvailable(driverId, isDriverAvailable)(),
+      ),
+      // 3. State transition
+      Result.map(transitionToEnRoute),
+      // 4. Persist
+      Result.andThrough(requestStore.save),
+    );
+```

--- a/docs/en/result-libraries/fp-ts.md
+++ b/docs/en/result-libraries/fp-ts.md
@@ -1,0 +1,165 @@
+---
+title: fp-ts
+parent: Error Handling
+grand_parent: English
+nav_order: 3
+---
+
+# fp-ts
+
+## Core API
+
+```typescript
+import * as E from "fp-ts/Either";
+import * as TE from "fp-ts/TaskEither";
+import { pipe } from "fp-ts/function";
+```
+
+| Function / Type | Description |
+|-----------------|-------------|
+| `Either<E, A>` | Synchronous Result type. Error is the first type parameter (Left); success is the second (Right) |
+| `TaskEither<E, A>` | Asynchronous Result type (`() => Promise<Either<E, A>>`) |
+| `E.right(value)` | Constructs a success value |
+| `E.left(error)` | Constructs a failure value |
+| `TE.Do` | Produces `TaskEither<never, {}>`. Starting point for incrementally building an object with `bind` |
+| `TE.bind(name, fn)` | Adds the result of `fn` to the success object under `name` |
+| `TE.chainFirst(fn)` | Runs a side effect; on success, returns the original value unchanged |
+| `TE.chainEitherK(fn)` | Lifts a synchronous `Either`-returning function into a `TaskEither` chain |
+
+## Composition with pipe
+
+In fp-ts, functions are composed with `pipe` rather than method chaining.
+
+```typescript
+pipe(
+  E.right(value),
+  E.map((a) => transform(a)),           // Transform the success value
+  E.mapLeft((e) => transformErr(e)),     // Transform the error value
+  E.chain((a) => nextEither(a)),         // Chain to the next Either (flatMap)
+  E.chainFirst((a) => sideEffect(a)),   // Run a side effect; preserve the original value on success
+  E.fold(
+    (error) => handleErr(error),
+    (value) => handleOk(value),
+  ),
+);
+
+// Do + bind: incrementally build an object
+pipe(
+  TE.Do,                                              // Start from TaskEither<never, {}>
+  TE.bind("user", () => findUser(userId)),            // { user: User }
+  TE.bind("order", ({ user }) => findOrder(user)),    // { user: User, order: Order }
+  TE.chainFirst(({ order }) => validate(order)),      // Validation (value is preserved)
+  TE.map(({ user, order }) => buildResponse(user, order)),
+);
+```
+
+## Example: State-Transition Pipeline
+
+Following Railway Oriented Programming principles, extract each step into an independent function and compose them in the use case using `pipe` + `Do` / `bind` / `chainFirst`.
+
+For the design of `RequestResolver` / `RequestStore` and how to persist state and domain events in a single transaction, see [state-modeling.md#domain-events](../state-modeling.md#ドメインイベント).
+
+```typescript
+import * as E from "fp-ts/Either";
+import * as TE from "fp-ts/TaskEither";
+import { pipe } from "fp-ts/function";
+
+// --- Branded Types ---
+
+declare const RequestIdBrand: unique symbol;
+type RequestId = string & { readonly [RequestIdBrand]: never };
+
+declare const DriverIdBrand: unique symbol;
+type DriverId = string & { readonly [DriverIdBrand]: never };
+
+declare const PassengerIdBrand: unique symbol;
+type PassengerId = string & { readonly [PassengerIdBrand]: never };
+
+// --- State Types ---
+
+type Waiting = Readonly<{
+  kind: "Waiting";
+  requestId: RequestId;
+  passengerId: PassengerId;
+}>;
+
+type EnRoute = Readonly<{
+  kind: "EnRoute";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  driverId: DriverId;
+}>;
+
+// --- Repository Types ---
+
+type RequestResolver = Readonly<{
+  findById: (id: RequestId) => TE.TaskEither<RepositoryError, Waiting | undefined>;
+}>;
+
+type RequestStore = Readonly<{
+  save: (state: EnRoute) => TE.TaskEither<RepositoryError, void>;
+}>;
+
+// --- Error Types ---
+
+type AssignDriverError =
+  | Readonly<{ kind: "RequestNotFound"; requestId: RequestId }>
+  | Readonly<{ kind: "DriverNotAvailable"; driverId: DriverId }>
+  | Readonly<{ kind: "RepositoryError"; cause: unknown }>;
+
+type RepositoryError = Readonly<{ kind: "RepositoryError"; cause: unknown }>;
+
+// --- Domain Functions ---
+
+const ensureExists =
+  (requestId: RequestId) =>
+  (request: Waiting | undefined): E.Either<AssignDriverError, Waiting> =>
+    request !== undefined
+      ? E.right(request)
+      : E.left({ kind: "RequestNotFound", requestId });
+
+const ensureDriverAvailable =
+  (driverId: DriverId, isAvailable: boolean) =>
+  (): E.Either<AssignDriverError, DriverId> =>
+    isAvailable
+      ? E.right(driverId)
+      : E.left({ kind: "DriverNotAvailable", driverId });
+
+const transitionToEnRoute = (ctx: {
+  waiting: Waiting;
+  driverId: DriverId;
+}): EnRoute => ({
+  kind: "EnRoute",
+  requestId: ctx.waiting.requestId,
+  passengerId: ctx.waiting.passengerId,
+  driverId: ctx.driverId,
+});
+
+// --- Use Case (full pipeline composition via Do + bind) ---
+
+const assignDriverUseCase =
+  (requestResolver: RequestResolver, requestStore: RequestStore) =>
+  (
+    requestId: RequestId,
+    driverId: DriverId,
+    isDriverAvailable: boolean,
+  ): TE.TaskEither<AssignDriverError, EnRoute> =>
+    pipe(
+      TE.Do,
+      // 1. Fetch request → verify existence
+      TE.bind("waiting", () =>
+        pipe(
+          requestResolver.findById(requestId),
+          TE.chainEitherK(ensureExists(requestId)),
+        ),
+      ),
+      // 2. Check driver availability
+      TE.bind("driverId", () =>
+        TE.fromEither(ensureDriverAvailable(driverId, isDriverAvailable)()),
+      ),
+      // 3. State transition
+      TE.map(transitionToEnRoute),
+      // 4. Persist
+      TE.chainFirst(requestStore.save),
+    );
+```

--- a/docs/en/result-libraries/neverthrow.md
+++ b/docs/en/result-libraries/neverthrow.md
@@ -1,0 +1,133 @@
+---
+title: neverthrow
+parent: Error Handling
+grand_parent: English
+nav_order: 1
+---
+
+# neverthrow
+
+## Core API
+
+```typescript
+import { ok, err, Result, ResultAsync } from "neverthrow";
+```
+
+| Function / Type | Description |
+|-----------------|-------------|
+| `Result<T, E>` | Synchronous Result type |
+| `ResultAsync<T, E>` | Asynchronous Result type (wrapper around `Promise<Result>`) |
+| `ok(value)` | Constructs a success value |
+| `err(error)` | Constructs a failure value |
+| `.andThrough(fn)` | Runs a side effect; on success, returns the original value unchanged |
+
+## Method Chaining
+
+```typescript
+result
+  .map((value) => transform(value))         // Transform the success value
+  .mapErr((error) => transformErr(error))    // Transform the error value
+  .andThen((value) => nextResult(value))     // Chain to the next Result (flatMap)
+  .andThrough((value) => sideEffect(value))  // Run a side effect; preserve the original value on success
+  .orElse((error) => recover(error))         // Recover from an error
+  .match(
+    (value) => handleOk(value),
+    (error) => handleErr(error),
+  );
+```
+
+## Example: State-Transition Pipeline
+
+Following Railway Oriented Programming principles, extract each step into an independent function and compose them in the use case with method chaining. Use `andThrough` to run side effects while preserving the current value.
+
+For the design of `RequestResolver` / `RequestStore` and how to persist state and domain events in a single transaction, see [state-modeling.md#domain-events](../state-modeling.md#ドメインイベント).
+
+```typescript
+import { ok, err, Result, ResultAsync } from "neverthrow";
+
+// --- Branded Types ---
+
+declare const RequestIdBrand: unique symbol;
+type RequestId = string & { readonly [RequestIdBrand]: never };
+
+declare const DriverIdBrand: unique symbol;
+type DriverId = string & { readonly [DriverIdBrand]: never };
+
+declare const PassengerIdBrand: unique symbol;
+type PassengerId = string & { readonly [PassengerIdBrand]: never };
+
+// --- State Types ---
+
+type Waiting = Readonly<{
+  kind: "Waiting";
+  requestId: RequestId;
+  passengerId: PassengerId;
+}>;
+
+type EnRoute = Readonly<{
+  kind: "EnRoute";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  driverId: DriverId;
+}>;
+
+// --- Repository Types ---
+
+type RequestResolver = Readonly<{
+  findById: (id: RequestId) => ResultAsync<Waiting | undefined, RepositoryError>;
+}>;
+
+type RequestStore = Readonly<{
+  save: (state: EnRoute) => ResultAsync<void, RepositoryError>;
+}>;
+
+// --- Error Types ---
+
+type AssignDriverError =
+  | Readonly<{ kind: "RequestNotFound"; requestId: RequestId }>
+  | Readonly<{ kind: "DriverNotAvailable"; driverId: DriverId }>
+  | Readonly<{ kind: "RepositoryError"; cause: unknown }>;
+
+type RepositoryError = Readonly<{ kind: "RepositoryError"; cause: unknown }>;
+
+// --- Domain Functions ---
+
+const ensureExists =
+  (requestId: RequestId) =>
+  (request: Waiting | undefined): Result<Waiting, AssignDriverError> =>
+    request !== undefined
+      ? ok(request)
+      : err({ kind: "RequestNotFound", requestId });
+
+const ensureDriverAvailable =
+  (driverId: DriverId, isAvailable: boolean) =>
+  (waiting: Waiting): Result<Waiting, AssignDriverError> =>
+    isAvailable
+      ? ok(waiting)
+      : err({ kind: "DriverNotAvailable", driverId });
+
+const transitionToEnRoute =
+  (driverId: DriverId) =>
+  (waiting: Waiting): EnRoute => ({
+    kind: "EnRoute",
+    requestId: waiting.requestId,
+    passengerId: waiting.passengerId,
+    driverId,
+  });
+
+// --- Use Case (pipeline composition via andThrough) ---
+
+const assignDriverUseCase =
+  (requestResolver: RequestResolver, requestStore: RequestStore) =>
+  (
+    requestId: RequestId,
+    driverId: DriverId,
+    isDriverAvailable: boolean,
+  ): ResultAsync<EnRoute, AssignDriverError> =>
+    requestResolver
+      .findById(requestId)
+      .andThen(ensureExists(requestId))
+      .andThen(ensureDriverAvailable(driverId, isDriverAvailable))
+      .map(transitionToEnRoute(driverId))
+      .andThrough(requestStore.save);
+```

--- a/docs/en/result-libraries/option-t.md
+++ b/docs/en/result-libraries/option-t.md
@@ -1,0 +1,153 @@
+---
+title: option-t
+parent: Error Handling
+grand_parent: English
+nav_order: 4
+---
+
+# option-t
+
+## Core API
+
+```typescript
+import { createOk, createErr, isOk, isErr, unwrapOk } from "option-t/plain_result";
+import { mapForResult } from "option-t/plain_result/map";
+import { andThenForResult } from "option-t/plain_result/and_then";
+import { andThenAsyncForResult } from "option-t/plain_result/and_then_async";
+import { mapErrForResult } from "option-t/plain_result/map_err";
+import { orElseForResult } from "option-t/plain_result/or_else";
+```
+
+Or with a namespace import:
+
+```typescript
+import { Result } from "option-t/plain_result/namespace";
+// Result.createOk, Result.map, Result.andThen, etc.
+```
+
+| Function / Type | Description |
+|-----------------|-------------|
+| `Result<T, E>` | Result type (`Ok<T> \| Err<E>` discriminated union, plain object) |
+| `createOk(value)` | Constructs a success value (`{ ok: true, val: T, err: null }`) |
+| `createErr(error)` | Constructs a failure value (`{ ok: false, val: null, err: E }`) |
+
+Key differences from neverthrow:
+
+- Plain objects instead of classes (discriminant is the `ok` field)
+- Composition via standalone functions instead of method chaining
+- Async operations use `*Async` variant functions (return type is `Promise<Result<T, E>>`)
+
+## Composition with Functions
+
+```typescript
+import { mapForResult } from "option-t/plain_result/map";
+import { mapErrForResult } from "option-t/plain_result/map_err";
+import { andThenForResult } from "option-t/plain_result/and_then";
+import { orElseForResult } from "option-t/plain_result/or_else";
+
+const mapped = mapForResult(result, (value) => transform(value));
+const mappedErr = mapErrForResult(result, (error) => transformErr(error));
+const chained = andThenForResult(result, (value) => nextResult(value));
+const recovered = orElseForResult(result, (error) => recover(error));
+
+// Branch with a type guard or the ok field
+if (isOk(result)) {
+  console.log(result.val);
+} else {
+  console.log(result.err);
+}
+```
+
+## Example: State-Transition Pipeline
+
+For the design of `RequestResolver` / `RequestStore` and how to persist state and domain events in a single transaction, see [state-modeling.md#domain-events](../state-modeling.md#ドメインイベント).
+
+```typescript
+import { createOk, createErr, isOk, isErr, type Result } from "option-t/plain_result";
+import { andThenForResult } from "option-t/plain_result/and_then";
+import { andThenAsyncForResult } from "option-t/plain_result/and_then_async";
+import { mapAsyncForResult } from "option-t/plain_result/map_async";
+
+// --- Branded Types ---
+
+declare const RequestIdBrand: unique symbol;
+type RequestId = string & { readonly [RequestIdBrand]: never };
+
+declare const DriverIdBrand: unique symbol;
+type DriverId = string & { readonly [DriverIdBrand]: never };
+
+declare const PassengerIdBrand: unique symbol;
+type PassengerId = string & { readonly [PassengerIdBrand]: never };
+
+// --- State Types ---
+
+type Waiting = Readonly<{
+  kind: "Waiting";
+  requestId: RequestId;
+  passengerId: PassengerId;
+}>;
+
+type EnRoute = Readonly<{
+  kind: "EnRoute";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  driverId: DriverId;
+}>;
+
+// --- Repository Types ---
+
+type RequestResolver = Readonly<{
+  findById: (id: RequestId) => Promise<Result<Waiting | undefined, RepositoryError>>;
+}>;
+
+type RequestStore = Readonly<{
+  save: (state: EnRoute) => Promise<Result<void, RepositoryError>>;
+}>;
+
+// --- Error Types ---
+
+type AssignDriverError =
+  | Readonly<{ kind: "RequestNotFound"; requestId: RequestId }>
+  | Readonly<{ kind: "DriverNotAvailable"; driverId: DriverId }>
+  | Readonly<{ kind: "RepositoryError"; cause: unknown }>;
+
+type RepositoryError = Readonly<{ kind: "RepositoryError"; cause: unknown }>;
+
+// --- Use Case ---
+
+const assignDriverUseCase =
+  (requestResolver: RequestResolver, requestStore: RequestStore) =>
+  async (
+    requestId: RequestId,
+    driverId: DriverId,
+    isDriverAvailable: boolean,
+  ): Promise<Result<EnRoute, AssignDriverError>> => {
+    const requestResult = await requestResolver.findById(requestId);
+
+    const waitingResult = andThenForResult(requestResult, (request) =>
+      request !== undefined
+        ? createOk(request)
+        : createErr({ kind: "RequestNotFound" as const, requestId }),
+    );
+
+    if (isErr(waitingResult)) return waitingResult;
+
+    const waiting = waitingResult.val;
+
+    if (!isDriverAvailable) {
+      return createErr({ kind: "DriverNotAvailable" as const, driverId });
+    }
+
+    const enRoute: EnRoute = {
+      kind: "EnRoute",
+      requestId: waiting.requestId,
+      passengerId: waiting.passengerId,
+      driverId,
+    };
+
+    const saveResult = await requestStore.save(enRoute);
+    if (isErr(saveResult)) return saveResult;
+
+    return createOk(enRoute);
+  };
+```

--- a/docs/en/state-modeling.md
+++ b/docs/en/state-modeling.md
@@ -1,0 +1,205 @@
+---
+title: State Transitions via Pure Functions
+parent: English
+nav_order: 2
+---
+
+# State Modeling — Detailed Guide
+
+## Designing State Transitions with Discriminated Unions
+
+### Design steps
+
+1. Enumerate all states a domain entity can occupy.
+2. Identify the properties required in each state.
+3. Define a distinct type per state, using `kind` as the discriminant.
+4. Combine them into a union type.
+5. Define valid transitions as pure functions.
+6. Group the functions in a Companion Object.
+
+### From a state-transition diagram to code
+
+```
+Waiting → EnRoute → InTrip → Completed
+  ↓         ↓        ↓
+Cancelled Cancelled Cancelled
+```
+
+This diagram translates to types and functions as follows.
+
+```typescript
+// 1. Types for each state
+type Waiting = Readonly<{
+  kind: "Waiting";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  createdAt: Date;
+}>;
+
+type EnRoute = Readonly<{
+  kind: "EnRoute";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  driverId: DriverId;
+  assignedAt: Date;
+}>;
+
+type InTrip = Readonly<{
+  kind: "InTrip";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  driverId: DriverId;
+  startedAt: Date;
+}>;
+
+type Completed = Readonly<{
+  kind: "Completed";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  driverId: DriverId;
+  startedAt: Date;
+  completedAt: Date;
+}>;
+
+type Cancelled = Readonly<{
+  kind: "Cancelled";
+  requestId: RequestId;
+  passengerId: PassengerId;
+  cancelledAt: Date;
+  reason: string;
+}>;
+
+// 2. Union type
+type TaxiRequest = Waiting | EnRoute | InTrip | Completed | Cancelled;
+
+// 3. Partial union for states that can be cancelled
+type CancellableRequest = Waiting | EnRoute | InTrip;
+
+// 4. Transition functions
+const TaxiRequest = {
+  assignDriver: (waiting: Waiting, driverId: DriverId, now: Date): EnRoute => ({
+    kind: "EnRoute",
+    requestId: waiting.requestId,
+    passengerId: waiting.passengerId,
+    driverId,
+    assignedAt: now,
+  }),
+
+  startTrip: (enRoute: EnRoute, now: Date): InTrip => ({
+    kind: "InTrip",
+    requestId: enRoute.requestId,
+    passengerId: enRoute.passengerId,
+    driverId: enRoute.driverId,
+    startedAt: now,
+  }),
+
+  complete: (inTrip: InTrip, now: Date): Completed => ({
+    kind: "Completed",
+    requestId: inTrip.requestId,
+    passengerId: inTrip.passengerId,
+    driverId: inTrip.driverId,
+    startedAt: inTrip.startedAt,
+    completedAt: now,
+  }),
+
+  cancel: (request: CancellableRequest, reason: string, now: Date): Cancelled => ({
+    kind: "Cancelled",
+    requestId: request.requestId,
+    passengerId: request.passengerId,
+    cancelledAt: now,
+    reason,
+  }),
+
+  isCancellable: (request: TaxiRequest): request is CancellableRequest =>
+    request.kind === "Waiting" ||
+    request.kind === "EnRoute" ||
+    request.kind === "InTrip",
+} as const;
+```
+
+### Notes
+
+**Shared properties:** Even when a property like `requestId` or `passengerId` is common to all states, avoid using `extends` to inherit from a base type. Interface inheritance introduces the declaration-merging problem described earlier. Accept the verbosity of explicitly listing shared properties in each state as the price of type safety.
+
+**Timestamps:** The examples above accept timestamps as arguments rather than calling `new Date()` internally. This makes it possible to inject an arbitrary time in tests, preserving testability.
+
+## Domain Events
+
+Record business occurrences that accompany state transitions as domain events.
+
+```typescript
+type DomainEvent<TName extends string, TPayload> = Readonly<{
+  eventId: string;
+  eventAt: Date;
+  eventName: TName;
+  payload: TPayload;
+  aggregateId: string;
+  aggregateName: string;
+}>;
+
+type DriverAssignedEvent = DomainEvent<
+  "DriverAssigned",
+  { driverId: DriverId; passengerId: PassengerId }
+>;
+
+type TripCompletedEvent = DomainEvent<
+  "TripCompleted",
+  { driverId: DriverId; duration: number }
+>;
+```
+
+### Persist state and events in the same transaction
+
+An aggregate's state and the events it emits must always be persisted within the same transaction boundary. A naive two-step write — state to one store, events to another — introduces the dual-write problem: if the first write succeeds and the second fails, consistency is broken.
+
+```typescript
+// Bad — state and events in separate transactions; a crash between writes breaks consistency
+saveRequest(entity).andThen(() => saveEvent(event));
+```
+
+The standard solution is the **Outbox Pattern**: the state-table UPDATE and the outbox-table INSERT happen in the same transaction, and a separate process relays outbox rows to the message broker. Express this atomicity in the interface itself. Separate the read side (`RequestResolver`) from the write side to honor the Interface Segregation Principle.
+
+```typescript
+type RequestResolver = Readonly<{
+  findById: (id: RequestId) => ResultAsync<Waiting | undefined, RepositoryError>;
+}>;
+
+type RequestStore = Readonly<{
+  save: (
+    state: EnRoute,
+    events: readonly DriverAssignedEvent[],
+  ) => ResultAsync<void, RepositoryError>;
+}>;
+```
+
+Enclosing everything in a single `save` method structurally prevents callers from reaching a half-written state where the aggregate was updated but no event was emitted.
+
+### Responsibility for event construction
+
+The use-case layer constructs events and passes them to `RequestStore.save` alongside the state. Having the repository generate events internally conflates persistence with business rules and inflates its responsibility.
+
+```typescript
+const buildDriverAssignedEvent =
+  (now: Date) =>
+  (enRoute: EnRoute): DriverAssignedEvent => ({
+    eventId: crypto.randomUUID(),
+    eventAt: now,
+    eventName: "DriverAssigned",
+    payload: { driverId: enRoute.driverId, passengerId: enRoute.passengerId },
+    aggregateId: enRoute.requestId,
+    aggregateName: "TaxiRequest",
+  });
+
+const assignDriverUseCase =
+  (requestResolver: RequestResolver, requestStore: RequestStore) =>
+  (requestId: RequestId, driverId: DriverId, now: Date) =>
+    requestResolver
+      .findById(requestId)
+      .andThen(validateWaiting)
+      .map(transitionToEnRoute(driverId))
+      .andThrough((enRoute) =>
+        requestStore.save(enRoute, [buildDriverAssignedEvent(now)(enRoute)]),
+      );
+```
+
+`now` is injected as a use-case argument. Avoiding `new Date()` inside the use case makes it possible to inject any timestamp in tests.

--- a/docs/en/test-data.md
+++ b/docs/en/test-data.md
@@ -1,0 +1,38 @@
+---
+title: Test Data
+parent: English
+nav_order: 6
+---
+
+# Test Data Guide
+
+## Defining Type-Safe Test Fixtures with `as const satisfies`
+
+Define dummy data for tests with `as const satisfies Type`. This preserves discriminant literal types and prevents widening.
+
+```typescript
+const waitingRequest = {
+  kind: "Waiting",
+  passengerId: "passenger-1" as PassengerId,
+} as const satisfies Waiting;
+
+// waitingRequest.kind is the "Waiting" literal type (not string)
+```
+
+### Why `as const` Alone Is Not Enough
+
+`as const` preserves literal types, but does not verify that the object is compatible with the expected type. Adding `satisfies Type` guarantees type compatibility at compile time while still keeping the literal types.
+
+```typescript
+// ❌ No type checking — typos go undetected
+const bad = {
+  kind: "Waitng", // typo is silently ignored
+  passengerId: "passenger-1" as PassengerId,
+} as const;
+
+// ✅ Type checked + literal types preserved
+const good = {
+  kind: "Waiting",
+  passengerId: "passenger-1" as PassengerId,
+} as const satisfies Waiting;
+```

--- a/docs/en/validation-libraries/arktype.md
+++ b/docs/en/validation-libraries/arktype.md
@@ -1,0 +1,106 @@
+---
+title: ArkType
+parent: Boundary Defense
+grand_parent: English
+nav_order: 3
+---
+
+# ArkType
+
+## Core API
+
+```typescript
+import { type } from "arktype";
+```
+
+| Function / Type | Description |
+|-----------------|-------------|
+| `type({...})` | Define an object type |
+| `type("string")` | String type |
+| `type("number")` | Number type |
+| `typeof Schema.infer` | Extract the TypeScript type from a schema |
+| `schema(raw)` | Returns validated data or a `type.errors` instance |
+| `schema.assert(raw)` | Returns validated data or throws |
+| `.brand("Name")` | Attach a nominal brand to the output type |
+| `.pipe(fn)` | Transform the validated value (morph) |
+| `"string.uuid"` | UUID format validation |
+| `"string.email"` | Email format validation |
+
+## Schema Definition
+
+```typescript
+const CreateRequestInput = type({
+  passengerId: "string.uuid",
+  pickupLocation: {
+    lat: "number >= -90 & number <= 90",
+    lng: "number >= -180 & number <= 180",
+  },
+});
+
+type CreateRequestInput = typeof CreateRequestInput.infer;
+```
+
+## Branded Types
+
+Use `.brand()` to define a brand. The brand is automatically attached to validated output — no `as` cast needed.
+
+```typescript
+const UserIdSchema = type("string.uuid").brand("UserId");
+type UserId = typeof UserIdSchema.infer;
+
+const ProductIdSchema = type("string.uuid").brand("ProductId");
+type ProductId = typeof ProductIdSchema.infer;
+
+// Validated output is already branded — no `as` cast needed
+```
+
+### Companion Object Pattern
+
+```typescript
+const RequestIdSchema = type("string.uuid").brand("RequestId");
+type RequestId = typeof RequestIdSchema.infer;
+
+const RequestId = {
+  schema: RequestIdSchema,
+  parse: schemaResult(RequestIdSchema), // see boundary-defense.md for schemaResult
+} as const;
+```
+
+## Integration with `Sensitive<T>`
+
+Use `.pipe()` to automatically wrap PII fields at validation time.
+
+```typescript
+const sensitiveString = type("string").pipe(Sensitive.of);
+
+const PatientSchema = type({
+  id: "string.uuid",
+  name: sensitiveString,
+  email: sensitiveString,
+  diagnosis: sensitiveString,
+  role: "string", // not PII — no wrapping
+});
+```
+
+## Handling Validation Results
+
+ArkType returns validated data directly on success or an `ArkErrors` instance on failure. Distinguish the two with `instanceof type.errors`.
+
+```typescript
+const result = CreateRequestInput(rawData);
+if (result instanceof type.errors) {
+  // result is ArkErrors — an array of ArkError objects
+  console.error(result.summary);
+} else {
+  // result is CreateRequestInput — validated data
+  console.log(result);
+}
+```
+
+## Guidelines
+
+- ArkType uses a call-based API (`schema(data)`); use `instanceof type.errors` to detect failure instead of `safeParse`.
+- The schema factory in [boundary-defense.md](../boundary-defense.md) uses the Standard Schema interface, so it works with ArkType without modification.
+- ArkType's type syntax mirrors TypeScript syntax (e.g. `"string | number"`, `"string[]"`), which keeps the learning curve low.
+- Optimized for both runtime performance and bundle size, making it well suited for edge environments.
+- `.brand()` eliminates `as` casts for Branded Types.

--- a/docs/en/validation-libraries/valibot.md
+++ b/docs/en/validation-libraries/valibot.md
@@ -1,0 +1,90 @@
+---
+title: Valibot
+parent: Boundary Defense
+grand_parent: English
+nav_order: 2
+---
+
+# Valibot
+
+## Core API
+
+```typescript
+import * as v from "valibot";
+```
+
+| Function / Type | Description |
+|-----------------|-------------|
+| `v.object({...})` | Object schema |
+| `v.string()` | String schema |
+| `v.number()` | Number schema |
+| `v.pipe(schema, ...actions)` | Chain validations and transforms |
+| `v.InferOutput<typeof Schema>` | Extract the TypeScript output type from a schema |
+| `v.safeParse(schema, raw)` | Returns `{ success, output, issues }` without throwing |
+| `v.parse(schema, raw)` | Returns parsed data or throws `ValiError` |
+| `v.brand("Name")` | Attach a nominal brand (used inside `pipe`) |
+| `v.transform(fn)` | Transform the parsed value (used inside `pipe`) |
+| `v.uuid()` | UUID format validation (used inside `pipe`) |
+
+## Schema Definition
+
+```typescript
+const CreateRequestInput = v.object({
+  passengerId: v.pipe(v.string(), v.uuid()),
+  pickupLocation: v.object({
+    lat: v.pipe(v.number(), v.minValue(-90), v.maxValue(90)),
+    lng: v.pipe(v.number(), v.minValue(-180), v.maxValue(180)),
+  }),
+});
+
+type CreateRequestInput = v.InferOutput<typeof CreateRequestInput>;
+```
+
+## Branded Types
+
+Use `v.brand()` inside `v.pipe()` to define a brand. The brand is automatically attached to the schema's output type — no `as` cast needed.
+
+```typescript
+const UserIdSchema = v.pipe(v.string(), v.uuid(), v.brand("UserId"));
+type UserId = v.InferOutput<typeof UserIdSchema>;
+
+const ProductIdSchema = v.pipe(v.string(), v.uuid(), v.brand("ProductId"));
+type ProductId = v.InferOutput<typeof ProductIdSchema>;
+
+// Output of v.parse() is already branded — no `as` cast needed
+```
+
+### Companion Object Pattern
+
+```typescript
+const RequestIdSchema = v.pipe(v.string(), v.uuid(), v.brand("RequestId"));
+type RequestId = v.InferOutput<typeof RequestIdSchema>;
+
+const RequestId = {
+  schema: RequestIdSchema,
+  parse: schemaResult(RequestIdSchema), // see boundary-defense.md for schemaResult
+} as const;
+```
+
+## Integration with `Sensitive<T>`
+
+Use `v.transform()` inside `v.pipe()` to automatically wrap PII fields at parse time.
+
+```typescript
+const sensitiveString = v.pipe(v.string(), v.transform(Sensitive.of));
+
+const PatientSchema = v.object({
+  id: v.pipe(v.string(), v.uuid()),
+  name: sensitiveString,
+  email: sensitiveString,
+  diagnosis: sensitiveString,
+  role: v.string(), // not PII — no wrapping
+});
+```
+
+## Guidelines
+
+- Use `v.safeParse` rather than `v.parse` for Railway Oriented Programming integration (see [boundary-defense.md](../boundary-defense.md) for the schema factory pattern).
+- The schema factory in boundary-defense.md conforms to Standard Schema, so it works with Valibot without modification.
+- Valibot is tree-shakeable and significantly lighter than Zod, making it ideal for edge environments such as Cloudflare Workers.
+- `v.brand()` eliminates `as` casts for Branded Types.

--- a/docs/en/validation-libraries/zod.md
+++ b/docs/en/validation-libraries/zod.md
@@ -1,0 +1,91 @@
+---
+title: Zod
+parent: Boundary Defense
+grand_parent: English
+nav_order: 1
+---
+
+# Zod
+
+## Core API
+
+```typescript
+import { z } from "zod";
+```
+
+| Function / Type | Description |
+|-----------------|-------------|
+| `z.object({...})` | Object schema |
+| `z.string()` | String schema |
+| `z.number()` | Number schema |
+| `z.infer<typeof Schema>` | Extract the TypeScript type from a schema |
+| `schema.safeParse(raw)` | Returns `{ success, data, error }` without throwing |
+| `schema.parse(raw)` | Returns parsed data or throws `ZodError` |
+| `z.brand<typeof Brand>()` | Attach a nominal brand to the output type (uses `unique symbol`) |
+| `.transform(fn)` | Transform the parsed value |
+
+## Schema Definition
+
+```typescript
+const CreateRequestInput = z.object({
+  passengerId: z.string().uuid(),
+  pickupLocation: z.object({
+    lat: z.number().min(-90).max(90),
+    lng: z.number().min(-180).max(180),
+  }),
+});
+
+type CreateRequestInput = z.infer<typeof CreateRequestInput>;
+```
+
+## Branded Types
+
+Use `z.brand()` to define a brand. The brand is automatically attached to the schema's output type, eliminating any need for `as` casts.
+
+```typescript
+export const UserIdBrand = Symbol();
+const UserIdSchema = z.string().uuid().brand<typeof UserIdBrand>();
+type UserId = z.infer<typeof UserIdSchema>;
+
+export const ProductIdBrand = Symbol();
+const ProductIdSchema = z.string().uuid().brand<typeof ProductIdBrand>();
+type ProductId = z.infer<typeof ProductIdSchema>;
+
+// safeParse().data is already branded — no `as` cast needed
+```
+
+### Companion Object Pattern
+
+```typescript
+export const RequestIdBrand = Symbol();
+const RequestIdSchema = z.string().uuid().brand<typeof RequestIdBrand>();
+type RequestId = z.infer<typeof RequestIdSchema>;
+
+const RequestId = {
+  schema: RequestIdSchema,
+  parse: schemaResult(RequestIdSchema), // see boundary-defense.md for schemaResult
+} as const;
+```
+
+## Integration with `Sensitive<T>`
+
+Use `.transform()` to automatically wrap PII fields at parse time.
+
+```typescript
+const sensitiveString = z.string().transform(Sensitive.of);
+
+const PatientSchema = z.object({
+  id: z.string().uuid(),
+  name: sensitiveString,
+  email: sensitiveString,
+  diagnosis: sensitiveString,
+  role: z.string(), // not PII — no wrapping
+});
+```
+
+## Guidelines
+
+- Use `safeParse` rather than `parse` for Railway Oriented Programming integration (see [boundary-defense.md](../boundary-defense.md) for the schema factory pattern).
+- The schema factory in boundary-defense.md conforms to Standard Schema, so it works with Zod without modification.
+- `z.brand()` eliminates `as` casts for Branded Types.
+- Use `unique symbol` (via `Symbol()`) as the brand key rather than a string literal — string literals break encapsulation and pollute autocomplete.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,11 @@ An extensible harness of skill plugins for designing and implementing robust ser
 
 ## English
 
-The English documentation lives in the skill source files in the GitHub repository:
+→ [English documentation](./en/)
+
+A reading version of the principles for practicing functional domain modeling in server-side TypeScript, reorganized as human-oriented prose.
+
+The original coding-agent skill sources also live in the GitHub repository:
 
 - [`skills/kamae`](https://github.com/iwasa-kosui/kamae-ts/tree/main/skills/kamae) — writing skill (functional domain modeling)
 - [`skills/kamae-review`](https://github.com/iwasa-kosui/kamae-ts/tree/main/skills/kamae-review) — code review skill


### PR DESCRIPTION
## Why

The published docs site at https://iwasa-kosui.github.io/kamae-ts/ shipped only a Japanese reading version under `/ja/`. English readers were redirected to the agent-facing skill sources on GitHub (`skills/kamae/**` etc.), which are written as instructions to a coding agent rather than as something a human reads top-to-bottom. That asymmetry made the site less useful as a public reference and underplayed the depth of material already written in `/ja/`.

## What

- Add a parallel `/en/` tree to `docs/`, mirroring the structure of `/ja/` one-to-one: a top-level index plus six principle chapters (domain modeling, state modeling, error handling, boundary defense, declarative style, test data), the adversarial code-review guide, four Result-library guides, and three validation-library guides. Frontmatter (`title`, `parent`, `grand_parent`, `nav_order`, `permalink`) and relative links are aligned with `/ja/` so the two trees can be updated in lockstep going forward.
- Register `en/`, `en/result-libraries`, and `en/validation-libraries` in the Jekyll `include` list of `docs/_config.yml`.
- Update `docs/index.md` (site home) so the English section links directly to `/en/` as a first-class reading version, with the GitHub skill sources demoted to a secondary reference list.
- Update both `README.md` and `README.ja.md` "Documentation" sections to surface `/en/` and `/ja/` symmetrically.

The term 構え (`kamae`) is kept verbatim in the English text rather than rendered as "stance", so the project's central concept stays recognisable across both languages.

## Test Plan

- [ ] After merge, confirm https://iwasa-kosui.github.io/kamae-ts/en/ renders with the full sidebar (index + 6 chapters + code-review + result-libraries + validation-libraries).
- [ ] Confirm the English/Japanese pages are both reachable from the site home.
- [ ] Spot-check that internal relative links inside `/en/` resolve (chapter ↔ index, error-handling ↔ result-libraries, boundary-defense ↔ validation-libraries).
- [ ] Confirm the README "Documentation" links resolve from the rendered GitHub README in both languages.

---
Generated with Claude Code
