### PR TITLE
docs(installation): add bilingual installation page to docs site

### DIFF
--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -1,0 +1,58 @@
+---
+title: Installation
+parent: English
+nav_order: 0
+---
+
+# Installation
+
+`kamae-ts` ships as a set of coding-agent skill plugins. Install them with either of the following CLIs.
+
+## Via `gh skill`
+
+[`gh skill`](https://cli.github.com/manual/gh_skill) is the GitHub CLI's agent skills extension.
+
+```bash
+# Install a single skill (interactive prompt for agent/scope)
+gh skill install iwasa-kosui/kamae-ts kamae
+
+# Install non-interactively for Claude Code at user scope
+gh skill install iwasa-kosui/kamae-ts kamae \
+  --agent claude-code --scope user
+
+# Pin to a specific release
+gh skill install iwasa-kosui/kamae-ts kamae@v1.0.0
+```
+
+## Via `skills` CLI
+
+[`skills`](https://github.com/anthropics/skills) is Anthropic's general-purpose skill installer.
+
+```bash
+npx skills add iwasa-kosui/kamae-ts
+```
+
+This installs every skill the plugin provides at once.
+
+## Provided skills
+
+| Skill | Triggered when |
+|-------|----------------|
+| [`kamae`](https://github.com/iwasa-kosui/kamae-ts/tree/main/skills/kamae) | Writing server-side TypeScript — domain models, use cases, repositories, state transitions, error handling, boundary validation, PII protection. |
+| [`kamae-review`](https://github.com/iwasa-kosui/kamae-ts/tree/main/skills/kamae-review) | Reviewing code. Walks a checklist of severity-tagged review items and cites the canonical principle in `kamae`. **Depends on `kamae` being installed** — install both together. |
+
+## Verifying the installation
+
+After installing, your coding agent should see `kamae` (and optionally `kamae-review`) listed among available skills. Refer to your agent's documentation for how to confirm — for example, in Claude Code, run `/skills` and look for `kamae-ts:kamae` in the list.
+
+## Customization
+
+Both skills load applicable rules from the following locations, in priority order:
+
+1. `.claude/rules/*.md` (project)
+2. `~/.claude/rules/*.md` (user-global)
+3. The plugin's own `rules/defaults/*.md`
+
+A rule applies to kamae-ts when its frontmatter declares `applies-to: kamae`, `applies-to: kamae-review`, or `applies-to: "*"`. See [`rules/README.md`](https://github.com/iwasa-kosui/kamae-ts/tree/main/rules) in the repository for the rule format and examples.
+
+For full skill replacement, use Claude Code's standard skill path-shadowing — `.claude/skills/kamae/SKILL.md` overrides the installed plugin's version.

--- a/docs/ja/installation.md
+++ b/docs/ja/installation.md
@@ -1,0 +1,58 @@
+---
+title: インストール
+parent: 日本語
+nav_order: 0
+---
+
+# インストール
+
+`kamae-ts` はコーディングエージェント向けのスキルプラグインとして配布している。以下のいずれかの CLI でインストールできる。
+
+## `gh skill` を使う
+
+[`gh skill`](https://cli.github.com/manual/gh_skill) は GitHub CLI のエージェントスキル拡張である。
+
+```bash
+# 単一スキルをインストール（エージェント／スコープを対話的に選択）
+gh skill install iwasa-kosui/kamae-ts kamae
+
+# Claude Code 向けに user スコープで非対話的にインストール
+gh skill install iwasa-kosui/kamae-ts kamae \
+  --agent claude-code --scope user
+
+# 特定のリリースに固定
+gh skill install iwasa-kosui/kamae-ts kamae@v1.0.0
+```
+
+## `skills` CLI を使う
+
+[`skills`](https://github.com/anthropics/skills) は Anthropic 公式の汎用スキルインストーラー。
+
+```bash
+npx skills add iwasa-kosui/kamae-ts
+```
+
+このコマンドはプラグインが提供する全スキルを一度にインストールする。
+
+## 提供スキル
+
+| スキル | トリガー条件 |
+|--------|--------------|
+| [`kamae`](https://github.com/iwasa-kosui/kamae-ts/tree/main/skills/kamae) | サーバーサイド TypeScript のコード生成時。ドメインモデル、ユースケース、リポジトリ、状態遷移、エラーハンドリング、境界バリデーション、PII 保護を扱う。 |
+| [`kamae-review`](https://github.com/iwasa-kosui/kamae-ts/tree/main/skills/kamae-review) | コードレビュー時。深刻度タグ付きのチェックリストを順に走査し、`kamae` の正典原則を引用して指摘する。**`kamae` のインストールに依存する** ため、両方を一緒に入れること。 |
+
+## インストールの確認
+
+インストール後、コーディングエージェントの利用可能スキル一覧に `kamae`（および `kamae-review`）が現れる。確認方法はエージェント側のドキュメントを参照すること。たとえば Claude Code では `/skills` を実行して `kamae-ts:kamae` が一覧に含まれていれば成功している。
+
+## カスタマイズ
+
+両スキルは起動時に以下の場所からルールを優先順位順に読み込む。
+
+1. `.claude/rules/*.md`（プロジェクト）
+2. `~/.claude/rules/*.md`（ユーザーグローバル）
+3. プラグイン同梱の `rules/defaults/*.md`
+
+ルールの frontmatter に `applies-to: kamae`、`applies-to: kamae-review`、または `applies-to: "*"` を宣言すると kamae-ts に適用される。ルール記法と具体例はリポジトリの [`rules/README.md`](https://github.com/iwasa-kosui/kamae-ts/tree/main/rules) を参照。
+
+スキル全体を差し替えたい場合は Claude Code 標準のスキルパスシャドウイングを使う。`.claude/skills/kamae/SKILL.md` を置けばインストール済みプラグインの定義を上書きできる。


### PR DESCRIPTION
## Why

The published docs site at https://iwasa-kosui.github.io/kamae-ts/ links into the principle reading guides under `/ja/` and `/en/`, but there is no Installation page on the site itself — newcomers have to bounce to `README.md` on GitHub to learn how to install the skills. Putting the instructions next to the reading material removes that hop.

## What

Add `docs/en/installation.md` and `docs/ja/installation.md` as children of the existing English / 日本語 sections, with `nav_order: 0` so the page appears at the top of each language's sidebar.

Content mirrors the README's Installation section (`gh skill` and `skills` CLI flows, including release pinning), plus a short table of provided skills, a verification tip, and a pointer to `rules/` for customization.

No `_config.yml` change needed — `ja/` and `en/` directories are already in `include:`, so the new files are picked up automatically.

## Test Plan

- [ ] Local Jekyll build (or wait for the Pages deploy) renders both pages with the correct parent in the just-the-docs sidebar
- [ ] Sidebar order: Installation appears above "Type-Driven Domain Modeling" / "型によるドメインモデリング"
- [ ] Cross-links to GitHub (`skills/kamae`, `skills/kamae-review`, `rules/`) resolve

---
Generated with Claude Code
