### PR TITLE
fix(docs): inject default og:image via Jekyll defaults

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,9 +2,13 @@ title: kamae-ts
 description: Kamae (構え) — robust server-side TypeScript design harness
 url: https://iwasa-kosui.github.io
 baseurl: /kamae-ts
-image: /assets/og-image.png
 twitter:
   card: summary_large_image
+defaults:
+  - scope:
+      path: ""
+    values:
+      image: /assets/og-image.png
 remote_theme: just-the-docs/just-the-docs
 plugins:
   - jekyll-remote-theme


### PR DESCRIPTION
## Why

`#29` wired up `jekyll-seo-tag` and committed `docs/assets/og-image.png`, but no preview card actually rendered when the docs site was shared. The site-level `image: /assets/og-image.png` in `_config.yml` was assumed to act as a default for OGP / Twitter card fallback — it does not. `jekyll-seo-tag`'s `ImageDrop` only resolves `page.image` and never reads `site.image`, so every page still emitted no `og:image` / `twitter:image`.

## What

Move the OG image into a Jekyll `defaults` block so it is injected as `page.image` on every page, which `jekyll-seo-tag` then emits as `og:image` and `twitter:image`. The redundant top-level `image:` key is removed since nothing in the current setup consumes it. Per-page overrides via front matter still take precedence.

## Test Plan

- [ ] After GitHub Pages rebuilds, view-source on the docs site root and confirm `og:image` and `twitter:image` meta tags are emitted with the absolute URL of `/assets/og-image.png`.
- [ ] Spot-check a deeper page (e.g. `/ja/`, `/en/`) for the same tags.
- [ ] Drop the URL into a card debugger (e.g. opengraph.xyz) and confirm the preview renders the committed PNG.

---
Generated with Claude Code
