### PR TITLE
docs(index): trim per-chapter prose and surface Discord community CTA

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -12,56 +12,26 @@ A reading version of the principles to follow when modeling domains in server-si
 
 This is a human-oriented reorganization of the knowledge base used by the coding-agent skills shipped in the [kamae-ts plugin](https://github.com/iwasa-kosui/kamae-ts).
 
-## 1. Type-Driven Domain Modeling
+## 💬 Join the Discord community
 
-Express domain state with Discriminated Unions and use `kind` as the unifying discriminant. Prefer `type` over `interface`, the Companion Object pattern, Branded Types, `Readonly<>`, function-property notation, and a one-concept-per-file layout.
+A Discord server for discussion, questions, and casual chat about server-side TypeScript and functional domain modeling. You do not need to be a heavy `kamae-ts` user — newcomers welcome.
 
-→ [domain-modeling.md](./domain-modeling.md)
+→ **[Join the Discord](https://discord.gg/Z9HVbqEWzd)**
 
-## 2. State Transitions via Pure Functions
+See the [Community page](./community.md) for details.
 
-Express state transitions with pure functions: argument types constrain valid source states, return types declare the target state, and invalid transitions become compile errors. Use `assertNever` to enforce exhaustiveness.
+## Start reading
 
-→ [state-modeling.md](./state-modeling.md)
+Each chapter is reachable from the left sidebar, or from the links below.
 
-## 3. Error Handling — Railway Oriented Programming
+- [Type-Driven Domain Modeling](./domain-modeling.md)
+- [State Transitions via Pure Functions](./state-modeling.md)
+- [Error Handling — Railway Oriented Programming](./error-handling.md)
+- [Boundary Defense](./boundary-defense.md)
+- [Declarative Style](./declarative-style.md)
+- [Test Data](./test-data.md)
+- [Code Review](./code-review.md)
 
-Do not throw exceptions; treat errors as values via Result types. Define error types as Discriminated Unions so callers can handle them exhaustively.
-
-Library guides: [neverthrow](./result-libraries/neverthrow.md) / [byethrow](./result-libraries/byethrow.md) / [fp-ts](./result-libraries/fp-ts.md) / [option-t](./result-libraries/option-t.md)
-
-→ [error-handling.md](./error-handling.md)
-
-## 4. Boundary Defense
-
-Validate external inputs (API requests, DB results, file reads) at runtime with a validation-library schema. Trust types inside the domain layer. Do not use type assertions — `as const` and `as const satisfies Type` are the only allowed forms; when the type is unknown, parse the value through a validation-library schema instead. Wrap PII fields in a `Sensitive<T>` wrapper.
-
-Library guides: [zod](./validation-libraries/zod.md) / [valibot](./validation-libraries/valibot.md) / [arktype](./validation-libraries/arktype.md)
-
-→ [boundary-defense.md](./boundary-defense.md)
-
-## 5. Declarative Style
-
-Transform arrays declaratively with `filter` / `map` / `reduce`, using predicate functions defined on the Companion Object. Model domain events as immutable records.
-
-→ [declarative-style.md](./declarative-style.md)
-
-## 6. Test Data
-
-Define test data with `as const satisfies Type` to preserve discriminant literal types and prevent widening.
-
-→ [test-data.md](./test-data.md)
-
-## Code Review
-
-For an adversarial code-review guide grounded in these principles, see [code-review.md](./code-review.md).
-
-## Applying the Principles
+## Applying the principles
 
 These are recommendations, not strict rules. Use judgment based on context, but when you depart from a principle, document the reason in a comment.
-
-Typical justified deviations:
-
-- An external library requires class inheritance.
-- Performance requirements make immutable-data construction costs problematic.
-- A team has agreed on a different pattern.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,25 +10,20 @@ nav_order: 1
 
 An extensible harness of skill plugins for designing and implementing robust server-side TypeScript applications. Each skill encodes a *kamae* — a practiced stance for a specific design concern — that coding agents apply when generating or reviewing code.
 
-## English
+## 💬 Join the community / コミュニティに参加する
 
-→ [English documentation](./en/)
+A Discord server for discussion, questions, and casual chat about server-side TypeScript and functional domain modeling. You do not need to be a `kamae-ts` user — newcomers welcome.
 
-A reading version of the principles for practicing functional domain modeling in server-side TypeScript, reorganized as human-oriented prose.
+サーバーサイド TypeScript や関数型ドメインモデリングについて議論・質問・雑談する場です。`kamae-ts` のユーザーである必要はありません。気軽にどうぞ。
 
-The original coding-agent skill sources also live in the GitHub repository:
+→ **[Join the Discord](https://discord.gg/Z9HVbqEWzd)**
 
-- [`skills/kamae`](https://github.com/iwasa-kosui/kamae-ts/tree/main/skills/kamae) — writing skill (functional domain modeling)
-- [`skills/kamae-review`](https://github.com/iwasa-kosui/kamae-ts/tree/main/skills/kamae-review) — code review skill
-- [`rules/`](https://github.com/iwasa-kosui/kamae-ts/tree/main/rules) — user customization mechanism
-- [`README.md`](https://github.com/iwasa-kosui/kamae-ts#readme) — install and overview
+## Documentation
 
-## 日本語
+- **[English](./en/)** — A reading version of the kamae-ts functional domain modeling principles.
+- **[日本語](./ja/)** — kamae-ts の関数型ドメインモデリング原則の読み物。
 
-→ [日本語ドキュメント](./ja/)
+## Source
 
-サーバーサイド TypeScript で関数型ドメインモデリングを実践するための原則を、人間の読み物として整理した日本語版を提供している。
-
-## License
-
-MIT — see [LICENSE](https://github.com/iwasa-kosui/kamae-ts/blob/main/LICENSE).
+- [GitHub repository](https://github.com/iwasa-kosui/kamae-ts) — skill sources, installation, and overview.
+- License: [MIT](https://github.com/iwasa-kosui/kamae-ts/blob/main/LICENSE).

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -10,58 +10,28 @@ permalink: /ja/
 
 サーバーサイド TypeScript でドメインモデルを書くときの原則をまとめた読み物です。class ベースの OOP ではなく、TypeScript の型システムを最大限に活用した関数型アプローチを採ります。
 
-これらは [kamae-ts プラグイン](https://github.com/iwasa-kosui/kamae-ts) が提供するコーディングエージェント向け skill の知識ベースを、人間の読み物として再構成したものです。
+[kamae-ts プラグイン](https://github.com/iwasa-kosui/kamae-ts) が提供するコーディングエージェント向け skill の知識ベースを、人間の読み物として再構成したものです。
 
-## 1. 型によるドメインモデリング
+## 💬 Discord コミュニティに参加する
 
-Discriminated Union で状態を表現し、`kind` を discriminant として統一します。`type`（`interface` ではなく）、Companion Object パターン、Branded Types、`Readonly<>`、関数プロパティ記法、1 概念 1 ファイル構成を採ります。
+サーバーサイド TypeScript や関数型ドメインモデリングについての議論・質問・雑談の場として Discord サーバーを運営しています。`kamae-ts` のヘビーユーザーである必要はありません。気軽にどうぞ。
 
-→ [domain-modeling.md](./domain-modeling.md)
+→ **[Discord に参加する](https://discord.gg/Z9HVbqEWzd)**
 
-## 2. 関数による状態遷移
+詳しくは [コミュニティ](./community.md) を参照してください。
 
-純粋関数で状態遷移を表現します。引数型が有効な遷移元を制約し、戻り値型が遷移先を明示します。無効な遷移はコンパイルエラーになります。`assertNever` で網羅性をチェックします。
+## 読み始める
 
-→ [state-modeling.md](./state-modeling.md)
+各章は左のサイドバー、または下のリンクから辿れます。
 
-## 3. エラーハンドリング — Railway Oriented Programming
-
-例外を throw せず、Result 型でエラーを値として扱います。エラー型は Discriminated Union で定義し、呼び出し元が網羅的にハンドルできるようにします。
-
-ライブラリ別ガイド: [neverthrow](./result-libraries/neverthrow.md) / [byethrow](./result-libraries/byethrow.md) / [fp-ts](./result-libraries/fp-ts.md) / [option-t](./result-libraries/option-t.md)
-
-→ [error-handling.md](./error-handling.md)
-
-## 4. 境界の防御
-
-外部入力（API リクエスト、DB 結果、ファイル読み込み）はバリデーションライブラリのスキーマで実行時バリデーションします。ドメイン層内部では型を信頼します。型アサーションは使いません — 許容するのは `as const` と `as const satisfies Type` のみで、型が不明なときはバリデーションライブラリのスキーマでパースします。PII フィールドには `Sensitive<T>` ラッパーを適用します。
-
-ライブラリ別ガイド: [zod](./validation-libraries/zod.md) / [valibot](./validation-libraries/valibot.md) / [arktype](./validation-libraries/arktype.md)
-
-→ [boundary-defense.md](./boundary-defense.md)
-
-## 5. 宣言的なスタイル
-
-配列の変換は `filter` / `map` / `reduce` で Companion Object の述語関数を使って宣言的に書きます。ドメインイベントは不変レコードとしてモデリングします。
-
-→ [declarative-style.md](./declarative-style.md)
-
-## 6. テストデータ
-
-テストデータは `as const satisfies Type` で定義し、discriminant のリテラル型を保持して widening を防ぎます。
-
-→ [test-data.md](./test-data.md)
-
-## コードレビュー
-
-これらの原則に基づいた敵対的コードレビューのガイドは [code-review.md](./code-review.md) を参照してください。
+- [型によるドメインモデリング](./domain-modeling.md)
+- [関数による状態遷移](./state-modeling.md)
+- [エラーハンドリング](./error-handling.md)
+- [境界の防御](./boundary-defense.md)
+- [宣言的なスタイル](./declarative-style.md)
+- [テストデータ](./test-data.md)
+- [コードレビュー](./code-review.md)
 
 ## 原則の適用について
 
 これらは推奨であり、厳格なルールではありません。コンテキストに応じて判断してかまいませんが、原則から逸脱する場合はその理由をコメントで明示してください。
-
-典型的な逸脱の正当理由は次のとおりです。
-
-- 外部ライブラリが class 継承を要求する場合
-- パフォーマンス要件により不変データの生成コストが問題になる場合
-- チームの合意により異なるパターンが採用されている場合


### PR DESCRIPTION
## Why

The top-level, `ja/`, and `en/` index pages each duplicated the just-the-docs sidebar TOC with paragraph-length descriptions of every chapter (`Discriminated Union で...`, `純粋関数で...`, etc.). Readers landing on the index had to wade through restated chapter content before finding any other entry point — and the Discord community invite, which is the only social CTA we have, was either buried at the bottom or absent entirely.

## What

- Cut the per-chapter explanatory paragraphs from all three index pages and replaced them with a title-only chapter list. The sidebar already lists chapters; the page no longer competes with it.
- Added a prominent `💬 Join the Discord community / コミュニティに参加する` section near the top of each index, with the invite link surfaced as the primary action.
- Top `index.md`: removed the per-skill GitHub bullet list (`skills/kamae`, `skills/kamae-review`, `rules/`, `README.md`) — it duplicated what the GitHub repository link already provides — and folded the License line into a `Source` block.
- Kept the short "Applying the principles / 原則の適用について" framing because it sets reader expectations, but trimmed the bulleted list of typical deviations (those belong in chapter pages, not the index).

## Test Plan

- [ ] Build the Jekyll site locally (or verify on the GitHub Pages preview) that `/`, `/ja/`, and `/en/` render with the new structure.
- [ ] Confirm the just-the-docs sidebar still lists all chapters and the new Discord CTA renders as a clickable link.
- [ ] Spot-check that `./community.md` relative links resolve under `/ja/` and `/en/`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
