### PR TITLE
docs(index): surface install commands and bilingualize section headings

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,11 +4,23 @@ description: Kamae (構え) — robust server-side TypeScript design harness
 nav_order: 1
 ---
 
-# kamae-ts
+# 🥋 kamae-ts
 
 > _Kamae (構え) — a stance of readiness._
 
 An extensible harness of skill plugins for designing and implementing robust server-side TypeScript applications. Each skill encodes a *kamae* — a practiced stance for a specific design concern — that coding agents apply when generating or reviewing code.
+
+## 📦 Install / インストール
+
+```bash
+# Install a single skill (interactive agent / scope selection)
+gh skill install iwasa-kosui/kamae-ts kamae
+
+# Or install every skill in one shot (Anthropic's installer)
+npx skills add iwasa-kosui/kamae-ts
+```
+
+Details, scope flags, and customization: **[English](./en/installation.md)** / **[日本語](./ja/installation.md)**.
 
 ## 💬 Join the community / コミュニティに参加する
 
@@ -18,12 +30,12 @@ A Discord server for discussion, questions, and casual chat about server-side Ty
 
 → **[Join the Discord](https://discord.gg/Z9HVbqEWzd)**
 
-## Documentation
+## 📚 Documentation / ドキュメント
 
 - **[English](./en/)** — A reading version of the kamae-ts functional domain modeling principles.
 - **[日本語](./ja/)** — kamae-ts の関数型ドメインモデリング原則の読み物。
 
-## Source
+## 🔗 Source / ソース
 
 - [GitHub repository](https://github.com/iwasa-kosui/kamae-ts) — skill sources, installation, and overview.
 - License: [MIT](https://github.com/iwasa-kosui/kamae-ts/blob/main/LICENSE).


### PR DESCRIPTION
## Why

The top index page surfaces the Discord CTA but never tells first-time visitors how to actually install the plugin — the only path was a generic "GitHub repository" link in the Source block. Readers landing cold had to dig through the README or sidebar pages to learn the install command.

Headings on the index were also half-bilingualized: `💬 Join the community / コミュニティに参加する` sat next to plain `Documentation` / `Source`, which read as unfinished.

## What

- Add a `📦 Install / インストール` block with the two canonical install commands (`gh skill install` and `npx skills add`), placed *above* the Discord CTA so install is the first action and community is the second.
- Link out to the bilingual `installation.md` pages for scope flags, customization, etc., rather than duplicating that detail on the index.
- Bilingualize the remaining section headings — `📚 Documentation / ドキュメント` and `🔗 Source / ソース` — so the page has one consistent style.
- Mark the H1 with 🥋 to align with the *kamae* naming and visually anchor the page.

## Test Plan

- [ ] Build the Jekyll site locally (or check the GitHub Pages preview) and confirm `/` renders the section order: Install -> Community -> Documentation -> Source.
- [ ] Confirm the `gh skill install` / `npx skills add` code block renders without smart-quote / backtick breakage.
- [ ] Spot-check that `./en/installation.md` and `./ja/installation.md` relative links resolve under `jekyll-relative-links`.
- [ ] Confirm the just-the-docs sidebar still lists all chapters and the Discord aux link is unchanged.

---
Generated with Claude Code
