### PR TITLE
feat(kamae-review): add semantic checks to 3.1/3.2/3.3 for Result pattern misuse

### DIFF
--- a/docs/en/code-review.md
+++ b/docs/en/code-review.md
@@ -110,13 +110,19 @@ Reference: [`./index.md` §3](./index.md), [`./error-handling.md`](./error-handl
 
 Signal: `throw` inside an entity, value object, or use case. Suggest converting to a `Result` type. Acceptable exceptions: `throw` inside `assertNever` (unreachable), and unexpected infrastructure failures in the infrastructure layer.
 
+Also flag: `ResultAsync.fromSafePromise` (or equivalent "safe" wrapper in other libraries) wrapping a Promise that can reject — database calls, network I/O, external API calls. `fromSafePromise` is a contract stating the Promise never rejects; violating it bypasses the Result error channel and produces an unhandled rejection at runtime. Suggest `fromPromise` with an explicit error mapper, and include the mapped error type in the function's error union. Reference: [`./error-handling.md` §fromSafePromise Misuse](./error-handling.md)
+
 #### 3.2 Error types defined as Discriminated Unions
 
 Signal: `Error` subclasses, free-form `string` error codes, or `Result<T, string>`. Suggest a Discriminated Union (`{ kind: "DriverNotAvailable"; driverId } | { kind: "RequestAlreadyAssigned" }`) so callers can handle errors exhaustively.
 
+Also flag: error DU variants where contextual data (IDs, codes, values that caused the error) exists only in a `message: string` field and is not exposed as typed fields. A `message` field itself is fine for logging or display, but when callers must parse it to extract values for branching or retry logic, the typed error has lost its purpose. Suggest adding the relevant context as named fields alongside `message`. Reference: [`./error-handling.md` §Designing Error Types](./error-handling.md)
+
 #### 3.3 Result chains used for composition (no premature unwrap)
 
 Verify that the project's Result-library API (`.map`, `.andThen`, `Result.do`, etc.) is used for chained composition. If the code immediately unwraps into `if/else`, cite the relevant guide under `./result-libraries/` and suggest an appropriate combinator.
+
+Also flag: `andThen` / `map` callbacks exceeding ~5 lines or containing multi-branch if/else logic. This is procedural code wrapped in a Result combinator, not Railway Oriented Programming. Suggest extracting each logical step into a named function so the chain reads as a flat pipeline of operations. Reference: [`./error-handling.md` §Composing Operations](./error-handling.md)
 
 ### 4. Boundary Defense
 

--- a/docs/en/error-handling.md
+++ b/docs/en/error-handling.md
@@ -11,15 +11,39 @@ has_children: true
 
 Use Result types to represent success and failure as values. Do not throw exceptions in the domain layer. For library-specific APIs, refer to the relevant guide under [result-libraries/](./result-libraries/).
 
-## Designing Error Types
+## fromSafePromise Misuse
 
-Define error types as Discriminated Unions so callers can handle them exhaustively.
+`ResultAsync.fromSafePromise` (neverthrow) and equivalent "safe" wrappers in other libraries assert that the wrapped Promise **never rejects**. Wrapping a Promise that can reject (database queries, HTTP calls, file I/O) violates that contract: on rejection the error bypasses the Result channel entirely and becomes an unhandled rejection.
 
 ```typescript
+// Bad: DB call can reject — fromSafePromise swallows that possibility
+ResultAsync.fromSafePromise(deps.getDriver(driverId))
+
+// Good: fromPromise with an explicit error mapper
+ResultAsync.fromPromise(
+  deps.getDriver(driverId),
+  (cause): RepositoryError => ({ kind: "RepositoryError", cause }),
+)
+```
+
+Use `fromSafePromise` only for Promises that are genuinely infallible — e.g. `Promise.resolve(value)`, in-memory lookups that never throw, or library calls documented to never reject.
+
+## Designing Error Types
+
+Define error types as Discriminated Unions so callers can handle them exhaustively. Each variant should expose contextual data as **typed fields**. A `message` field for logging or display is fine, but it must not be the only place where context values live — callers that need to branch or retry based on those values should not have to parse a string.
+
+```typescript
+// Good: context available as typed fields; message is optional and for display only
 type AssignDriverError =
   | Readonly<{ kind: "RequestNotFound"; requestId: RequestId }>
   | Readonly<{ kind: "InvalidState"; currentKind: string; expectedKind: "Waiting" }>
-  | Readonly<{ kind: "DriverNotAvailable"; driverId: DriverId }>;
+  | Readonly<{ kind: "DriverNotAvailable"; driverId: DriverId; message?: string }>;
+
+// Bad: driverId and zoneId exist only inside message — callers must parse to extract them
+type DriverNotAvailableError = Readonly<{
+  kind: "DriverNotAvailableError";
+  message: string; // "Driver drv-123 is not available in zone zone-A"
+}>;
 ```
 
 ### Error Type Granularity

--- a/docs/ja/code-review.md
+++ b/docs/ja/code-review.md
@@ -110,13 +110,19 @@ declaration merging により型の形状が暗黙に変わる危険がありま
 
 兆候: エンティティ・値オブジェクト・ユースケース内の `throw`。`Result` 型への変更を提案します。許容するのは `assertNever` 内の throw（到達不能）と、インフラ層の予期しない障害です。
 
+`ResultAsync.fromSafePromise`（または他ライブラリの同等の「safe」ラッパー）で reject しうる Promise（DB 呼び出し、ネットワーク I/O、外部 API 呼び出し）をラップしている場合も指摘します。`fromSafePromise` は「この Promise は reject しない」という契約であり、違反すると Result のエラーチャネルを迂回してハンドルされない rejection が発生します。`fromPromise` と明示的なエラーマッパーへの変更を提案し、マッピング後のエラー型を関数のエラー union に含めるよう求めます。参照: [`./error-handling.md` §fromSafePromise の誤用](./error-handling.md)
+
 #### 3.2 エラー型が Discriminated Union になっているか
 
 兆候: `Error` のサブクラス、自由形式の `string` エラーコード、`Result<T, string>`。Discriminated Union（`{ kind: "DriverNotAvailable"; driverId } | { kind: "RequestAlreadyAssigned" }`）への変更を提案し、呼び出し元が網羅的に分岐できるようにします。
 
+エラー DU のバリアントで、コンテキストデータ（ID、コード、エラーの原因となった値）が `message: string` にしか存在せず、型付きフィールドとして公開されていない場合も指摘します。`message` フィールド自体はログや表示用に持っていて構いませんが、分岐やリトライに必要な値を message のパースで取得しなければならない状態は、型付きエラーの利点を失わせます。関連するコンテキストを `message` と並行して名前付きフィールドとして追加するよう提案します。参照: [`./error-handling.md` §エラー型の設計](./error-handling.md)
+
 #### 3.3 Result チェーンを使って合成しているか（即 unwrap していないか）
 
 プロジェクトに対応する Result ライブラリの API（`.map`、`.andThen`、`Result.do` など）でチェーン合成しているかを確認します。即 unwrap して if/else に展開している場合は、`./result-libraries/` 配下の該当ガイドを引用して適切なコンビネータを提案します。
+
+`andThen` / `map` のコールバックが約 5 行を超えていたり、複数分岐の if/else ロジックを含んでいたりする場合も指摘します。これは Result コンビネータで包んだ手続き的コードであり、Railway Oriented Programming ではありません。各論理ステップを名前付き関数に抽出し、チェーンがフラットなパイプラインとして読めるようにすることを提案します。参照: [`./error-handling.md` §処理の合成](./error-handling.md)
 
 ### 4. 境界の防御
 

--- a/docs/ja/error-handling.md
+++ b/docs/ja/error-handling.md
@@ -11,15 +11,39 @@ has_children: true
 
 Result 型を使い、成功と失敗を型で表現します。例外の throw はドメイン層では使いません。ライブラリ固有の API については [result-libraries/](./result-libraries/) 内の該当ガイドを参照してください。
 
-## エラー型の設計
+## fromSafePromise の誤用
 
-エラーも Discriminated Union で定義し、呼び出し元が網羅的にハンドルできるようにします。
+`ResultAsync.fromSafePromise`（neverthrow）や他ライブラリの同等の「safe」ラッパーは、渡された Promise が **reject しない** ことを前提にしています。reject しうる Promise（DB クエリ、HTTP 呼び出し、ファイル I/O など）をラップすると、reject 時にエラーが Result チャネルを迂回し、ハンドルされない rejection になります。
 
 ```typescript
+// Bad: DB呼び出しはrejectしうる — fromSafePromiseではその可能性が無視される
+ResultAsync.fromSafePromise(deps.getDriver(driverId))
+
+// Good: fromPromiseで明示的にエラーをマッピング
+ResultAsync.fromPromise(
+  deps.getDriver(driverId),
+  (cause): RepositoryError => ({ kind: "RepositoryError", cause }),
+)
+```
+
+`fromSafePromise` を使ってよいのは、本当に reject しない Promise だけです — `Promise.resolve(value)` やインメモリのルックアップ、reject しないことがドキュメントに明記されたライブラリ呼び出しなどが該当します。
+
+## エラー型の設計
+
+エラーも Discriminated Union で定義し、呼び出し元が網羅的にハンドルできるようにします。各バリアントは、コンテキストデータを **型付きフィールド** として公開します。ログや表示用の `message` フィールドを持つこと自体は問題ありませんが、コンテキストの値が `message` にしか存在しない状態は避けます。分岐やリトライに必要な値を文字列からパースしなければならなくなるためです。
+
+```typescript
+// Good: コンテキストが型付きフィールドとして利用可能。messageは表示用で省略可
 type AssignDriverError =
   | Readonly<{ kind: "RequestNotFound"; requestId: RequestId }>
   | Readonly<{ kind: "InvalidState"; currentKind: string; expectedKind: "Waiting" }>
-  | Readonly<{ kind: "DriverNotAvailable"; driverId: DriverId }>;
+  | Readonly<{ kind: "DriverNotAvailable"; driverId: DriverId; message?: string }>;
+
+// Bad: driverIdとzoneIdがmessageの中にしかない — 取り出すにはパースが必要
+type DriverNotAvailableError = Readonly<{
+  kind: "DriverNotAvailableError";
+  message: string; // "Driver drv-123 is not available in zone zone-A"
+}>;
 ```
 
 ### エラー型の粒度

--- a/evals/kamae-review/fixtures/violations/error-context-in-message.ts
+++ b/evals/kamae-review/fixtures/violations/error-context-in-message.ts
@@ -1,0 +1,69 @@
+import { ok, err, Result } from "neverthrow";
+
+declare const DriverIdBrand: unique symbol;
+type DriverId = string & { readonly [DriverIdBrand]: never };
+
+declare const ZoneIdBrand: unique symbol;
+type ZoneId = string & { readonly [ZoneIdBrand]: never };
+
+declare const RequestIdBrand: unique symbol;
+type RequestId = string & { readonly [RequestIdBrand]: never };
+
+type DriverNotAvailableError = Readonly<{
+  kind: "DriverNotAvailableError";
+  message: string;
+}>;
+
+const DriverNotAvailableError = {
+  new: (driverId: DriverId, zoneId: ZoneId): DriverNotAvailableError => ({
+    kind: "DriverNotAvailableError",
+    message: `Driver ${driverId} is not available in zone ${zoneId}`,
+  }),
+} as const;
+
+type RequestNotFoundError = Readonly<{
+  kind: "RequestNotFoundError";
+  message: string;
+}>;
+
+const RequestNotFoundError = {
+  new: (requestId: RequestId): RequestNotFoundError => ({
+    kind: "RequestNotFoundError",
+    message: `Request ${requestId} not found`,
+  }),
+} as const;
+
+type AssignDriverError = DriverNotAvailableError | RequestNotFoundError;
+
+type Driver = Readonly<{
+  id: DriverId;
+  isAvailable: boolean;
+  currentZone: ZoneId;
+}>;
+
+type Request = Readonly<{
+  kind: "Waiting";
+  requestId: RequestId;
+  zoneId: ZoneId;
+}>;
+
+export const validateAssignment = (
+  request: Request,
+  driver: Driver,
+): Result<Request, AssignDriverError> => {
+  if (!driver.isAvailable) {
+    return err(DriverNotAvailableError.new(driver.id, request.zoneId));
+  }
+  return ok(request);
+};
+
+export const findRequest = (
+  requestId: RequestId,
+  requests: ReadonlyArray<Request>,
+): Result<Request, AssignDriverError> => {
+  const found = requests.find((r) => r.requestId === requestId);
+  if (!found) {
+    return err(RequestNotFoundError.new(requestId));
+  }
+  return ok(found);
+};

--- a/evals/kamae-review/fixtures/violations/from-safe-promise-misuse.ts
+++ b/evals/kamae-review/fixtures/violations/from-safe-promise-misuse.ts
@@ -1,0 +1,62 @@
+import { ResultAsync, okAsync, errAsync } from "neverthrow";
+
+declare const RequestIdBrand: unique symbol;
+type RequestId = string & { readonly [RequestIdBrand]: never };
+
+declare const DriverIdBrand: unique symbol;
+type DriverId = string & { readonly [DriverIdBrand]: never };
+
+type Waiting = Readonly<{
+  kind: "Waiting";
+  requestId: RequestId;
+}>;
+
+type EnRoute = Readonly<{
+  kind: "EnRoute";
+  requestId: RequestId;
+  driverId: DriverId;
+}>;
+
+type Assignment = Waiting | EnRoute;
+
+type AssignDriverError =
+  | Readonly<{ kind: "RequestNotFound"; requestId: RequestId }>
+  | Readonly<{ kind: "DriverNotAvailable"; driverId: DriverId }>;
+
+type AssignDriverDeps = Readonly<{
+  getRequest: (id: RequestId) => Promise<Waiting | undefined>;
+  checkDriverAvailable: (id: DriverId) => Promise<boolean>;
+  save: (assignment: EnRoute) => Promise<void>;
+}>;
+
+type AssignDriverInput = Readonly<{
+  requestId: RequestId;
+  driverId: DriverId;
+}>;
+
+export const assignDriver = (
+  deps: AssignDriverDeps,
+  input: AssignDriverInput,
+): ResultAsync<EnRoute, AssignDriverError> =>
+  ResultAsync.fromSafePromise(deps.getRequest(input.requestId))
+    .andThen((request) =>
+      request !== undefined
+        ? okAsync(request)
+        : errAsync({ kind: "RequestNotFound" as const, requestId: input.requestId }),
+    )
+    .andThen((waiting) =>
+      ResultAsync.fromSafePromise(deps.checkDriverAvailable(input.driverId)).andThen(
+        (available) =>
+          available
+            ? okAsync(waiting)
+            : errAsync({ kind: "DriverNotAvailable" as const, driverId: input.driverId }),
+      ),
+    )
+    .andThen((waiting) => {
+      const enRoute: EnRoute = {
+        kind: "EnRoute",
+        requestId: waiting.requestId,
+        driverId: input.driverId,
+      };
+      return ResultAsync.fromSafePromise(deps.save(enRoute)).map(() => enRoute);
+    });

--- a/evals/kamae-review/fixtures/violations/procedural-andthen.ts
+++ b/evals/kamae-review/fixtures/violations/procedural-andthen.ts
@@ -1,0 +1,84 @@
+import { ResultAsync, okAsync, errAsync } from "neverthrow";
+
+declare const DriverIdBrand: unique symbol;
+type DriverId = string & { readonly [DriverIdBrand]: never };
+
+declare const ZoneIdBrand: unique symbol;
+type ZoneId = string & { readonly [ZoneIdBrand]: never };
+
+declare const RequestIdBrand: unique symbol;
+type RequestId = string & { readonly [RequestIdBrand]: never };
+
+type Driver = Readonly<{
+  id: DriverId;
+  isAvailable: boolean;
+  currentZone: ZoneId;
+}>;
+
+type Assignment = Readonly<{
+  requestId: RequestId;
+  driverId: DriverId;
+  isValid: boolean;
+}>;
+
+type DriverNotFoundError = Readonly<{ kind: "DriverNotFoundError"; driverId: DriverId }>;
+type DriverNotAvailableError = Readonly<{ kind: "DriverNotAvailableError"; driverId: DriverId; zoneId: ZoneId }>;
+type DriverOutOfZoneError = Readonly<{ kind: "DriverOutOfZoneError"; driverId: DriverId; zoneId: ZoneId }>;
+type InvalidAssignmentError = Readonly<{ kind: "InvalidAssignmentError"; requestId: RequestId; driverId: DriverId }>;
+
+type AssignDriverError =
+  | DriverNotFoundError
+  | DriverNotAvailableError
+  | DriverOutOfZoneError
+  | InvalidAssignmentError;
+
+type AssignDriverDeps = Readonly<{
+  getDriver: (id: DriverId) => Promise<Driver | undefined>;
+}>;
+
+const computeAssignment = (driver: Driver, requestId: RequestId): Assignment => ({
+  requestId,
+  driverId: driver.id,
+  isValid: driver.isAvailable,
+});
+
+export const assignDriver = (
+  deps: AssignDriverDeps,
+  requestId: RequestId,
+  driverId: DriverId,
+  zoneId: ZoneId,
+): ResultAsync<Assignment, AssignDriverError> =>
+  ResultAsync.fromPromise(
+    deps.getDriver(driverId),
+    (): DriverNotFoundError => ({ kind: "DriverNotFoundError", driverId }),
+  ).andThen((driver) => {
+    if (!driver) {
+      return errAsync<Assignment, AssignDriverError>({
+        kind: "DriverNotFoundError",
+        driverId,
+      });
+    }
+    if (!driver.isAvailable) {
+      return errAsync<Assignment, AssignDriverError>({
+        kind: "DriverNotAvailableError",
+        driverId,
+        zoneId,
+      });
+    }
+    if (driver.currentZone !== zoneId) {
+      return errAsync<Assignment, AssignDriverError>({
+        kind: "DriverOutOfZoneError",
+        driverId,
+        zoneId,
+      });
+    }
+    const assignment = computeAssignment(driver, requestId);
+    if (!assignment.isValid) {
+      return errAsync<Assignment, AssignDriverError>({
+        kind: "InvalidAssignmentError",
+        requestId,
+        driverId,
+      });
+    }
+    return okAsync(assignment);
+  });

--- a/evals/kamae-review/tasks/flag-error-context-in-message.yaml
+++ b/evals/kamae-review/tasks/flag-error-context-in-message.yaml
@@ -1,0 +1,19 @@
+id: kamae-review-error-context-001
+name: Flag error DU variants with context buried in message string
+description: |
+  The fixture defines error Discriminated Unions that are structurally correct
+  (have a kind discriminant) but embed contextual data (driverId, requestId)
+  only inside a message string. The reviewer should flag this as a 3.2 violation
+  and suggest adding typed fields for the contextual data.
+
+inputs:
+  prompt: |
+    Review the attached TypeScript file as part of a pull request and report
+    findings against the kamae principles. Cite the relevant principle for
+    each finding and tag severity (High / Medium / Low / Suggestion).
+  files:
+    - path: violations/error-context-in-message.ts
+
+expected:
+  outcomes:
+    - type: task_completed

--- a/evals/kamae-review/tasks/flag-from-safe-promise-misuse.yaml
+++ b/evals/kamae-review/tasks/flag-from-safe-promise-misuse.yaml
@@ -1,0 +1,18 @@
+id: kamae-review-safe-promise-001
+name: Flag fromSafePromise wrapping fallible Promises
+description: |
+  The fixture uses ResultAsync.fromSafePromise to wrap database calls and
+  network I/O that can reject. The reviewer should flag this as a 3.1 violation
+  (fromSafePromise misuse) and suggest fromPromise with an error mapper.
+
+inputs:
+  prompt: |
+    Review the attached TypeScript file as part of a pull request and report
+    findings against the kamae principles. Cite the relevant principle for
+    each finding and tag severity (High / Medium / Low / Suggestion).
+  files:
+    - path: violations/from-safe-promise-misuse.ts
+
+expected:
+  outcomes:
+    - type: task_completed

--- a/evals/kamae-review/tasks/flag-procedural-andthen.yaml
+++ b/evals/kamae-review/tasks/flag-procedural-andthen.yaml
@@ -1,0 +1,19 @@
+id: kamae-review-procedural-001
+name: Flag procedural if/else logic inside andThen callback
+description: |
+  The fixture wraps multi-branch if/else logic inside a single andThen callback
+  instead of composing named functions into a flat pipeline. The reviewer should
+  flag this as a 3.3 violation and suggest extracting each check into a named
+  function.
+
+inputs:
+  prompt: |
+    Review the attached TypeScript file as part of a pull request and report
+    findings against the kamae principles. Cite the relevant principle for
+    each finding and tag severity (High / Medium / Low / Suggestion).
+  files:
+    - path: violations/procedural-andthen.ts
+
+expected:
+  outcomes:
+    - type: task_completed

--- a/skills/kamae-review/checklist/error-handling.md
+++ b/skills/kamae-review/checklist/error-handling.md
@@ -6,10 +6,16 @@ Reference: [`../../kamae/SKILL.md` §3](../../kamae/SKILL.md), [`../../kamae/err
 
 Flag: `throw` in entities, value objects, or use cases. Suggest migrating to `Result`. Acceptable: `throw` inside `assertNever` (unreachable) and unexpected failures in the infrastructure layer.
 
+Also flag: `ResultAsync.fromSafePromise` (or equivalent "safe" wrapper in other libraries) wrapping a Promise that can reject — database calls, network I/O, external API calls. `fromSafePromise` is a contract stating the Promise never rejects; violating it bypasses the Result error channel and produces an unhandled rejection at runtime. Suggest `fromPromise` with an explicit error mapper, and include the mapped error type in the function's error union. See [`../../kamae/error-handling.md` §fromSafePromise](../../kamae/error-handling.md).
+
 ## 3.2 Are error types Discriminated Unions? — Medium
 
 Flag: `Error` subclasses, free-form `string` error codes, or `Result<T, string>`. Suggest a Discriminated Union (`{ kind: "DriverNotAvailable"; driverId } | { kind: "RequestAlreadyAssigned" }`) so callers can branch exhaustively.
 
+Also flag: error DU variants where contextual data (IDs, codes, values that caused the error) is embedded only in a `message: string` field and not available as typed fields. Callers that need the raw values (e.g. `driverId` for a retry) are forced to parse the message string, defeating the purpose of typed errors. Suggest adding the relevant context as named fields alongside or instead of `message`. See [`../../kamae/error-handling.md` §Error Type Design](../../kamae/error-handling.md).
+
 ## 3.3 Are Result chains used instead of nested if/else? — Low
 
 Verify that the project uses the matching Result library API (`.map`, `.andThen`, `Result.do`, …) rather than unwrapping immediately into branching code. Cite the matching guide under `../../kamae/result-libraries/` for the correct combinator.
+
+Also flag: `andThen` / `map` callbacks exceeding ~5 lines or containing multi-branch if/else logic. This is procedural code wrapped in a Result combinator, not Railway Oriented Programming. Suggest extracting each logical step into a named function so the chain reads as a flat pipeline of operations. See [`../../kamae/error-handling.md` §Composing Operations](../../kamae/error-handling.md).

--- a/skills/kamae-review/checklist/error-handling.md
+++ b/skills/kamae-review/checklist/error-handling.md
@@ -12,7 +12,7 @@ Also flag: `ResultAsync.fromSafePromise` (or equivalent "safe" wrapper in other 
 
 Flag: `Error` subclasses, free-form `string` error codes, or `Result<T, string>`. Suggest a Discriminated Union (`{ kind: "DriverNotAvailable"; driverId } | { kind: "RequestAlreadyAssigned" }`) so callers can branch exhaustively.
 
-Also flag: error DU variants where contextual data (IDs, codes, values that caused the error) is embedded only in a `message: string` field and not available as typed fields. Callers that need the raw values (e.g. `driverId` for a retry) are forced to parse the message string, defeating the purpose of typed errors. Suggest adding the relevant context as named fields alongside or instead of `message`. See [`../../kamae/error-handling.md` §Error Type Design](../../kamae/error-handling.md).
+Also flag: error DU variants where contextual data (IDs, codes, values that caused the error) exists only in a `message: string` field and is not exposed as typed fields. A `message` field itself is fine for logging or display, but when callers must parse it to extract values for branching or retry logic, the typed error has lost its purpose. Suggest adding the relevant context as named fields alongside `message`. See [`../../kamae/error-handling.md` §Error Type Design](../../kamae/error-handling.md).
 
 ## 3.3 Are Result chains used instead of nested if/else? — Low
 

--- a/skills/kamae/error-handling.md
+++ b/skills/kamae/error-handling.md
@@ -4,15 +4,39 @@
 
 Use Result types to represent success and failure in the type system. Do not throw exceptions in the domain layer. For library-specific APIs, refer to the corresponding guide in [result-libraries/](./result-libraries/).
 
-## Error Type Design
+## fromSafePromise Misuse
 
-Define errors as Discriminated Unions so that callers can handle them exhaustively.
+`ResultAsync.fromSafePromise` (neverthrow) and equivalent "safe" wrappers in other libraries assert that the wrapped Promise **never rejects**. Wrapping a Promise that can reject (database queries, HTTP calls, file I/O) violates that contract: on rejection the error bypasses the Result channel entirely and becomes an unhandled rejection.
 
 ```typescript
+// Bad: DB call can reject — fromSafePromise swallows that possibility
+ResultAsync.fromSafePromise(deps.getDriver(driverId))
+
+// Good: fromPromise with an explicit error mapper
+ResultAsync.fromPromise(
+  deps.getDriver(driverId),
+  (cause): RepositoryError => ({ kind: "RepositoryError", cause }),
+)
+```
+
+Use `fromSafePromise` only for Promises that are genuinely infallible — e.g. `Promise.resolve(value)`, in-memory lookups that never throw, or library calls documented to never reject.
+
+## Error Type Design
+
+Define errors as Discriminated Unions so that callers can handle them exhaustively. Each variant should expose contextual data as **typed fields**, not buried inside a `message` string.
+
+```typescript
+// Good: context available as typed fields
 type AssignDriverError =
   | Readonly<{ kind: "RequestNotFound"; requestId: RequestId }>
   | Readonly<{ kind: "InvalidState"; currentKind: string; expectedKind: "Waiting" }>
   | Readonly<{ kind: "DriverNotAvailable"; driverId: DriverId }>;
+
+// Bad: context baked into message — callers must parse to extract driverId
+type DriverNotAvailableError = Readonly<{
+  kind: "DriverNotAvailableError";
+  message: string; // "Driver drv-123 is not available"
+}>;
 ```
 
 ### Error Type Granularity

--- a/skills/kamae/error-handling.md
+++ b/skills/kamae/error-handling.md
@@ -23,19 +23,19 @@ Use `fromSafePromise` only for Promises that are genuinely infallible — e.g. `
 
 ## Error Type Design
 
-Define errors as Discriminated Unions so that callers can handle them exhaustively. Each variant should expose contextual data as **typed fields**, not buried inside a `message` string.
+Define errors as Discriminated Unions so that callers can handle them exhaustively. Each variant should expose contextual data as **typed fields**. A `message` field for logging or display is fine, but it must not be the only place where context values live — callers that need to branch or retry based on those values should not have to parse a string.
 
 ```typescript
-// Good: context available as typed fields
+// Good: context available as typed fields; message is optional and for display only
 type AssignDriverError =
   | Readonly<{ kind: "RequestNotFound"; requestId: RequestId }>
   | Readonly<{ kind: "InvalidState"; currentKind: string; expectedKind: "Waiting" }>
-  | Readonly<{ kind: "DriverNotAvailable"; driverId: DriverId }>;
+  | Readonly<{ kind: "DriverNotAvailable"; driverId: DriverId; message?: string }>;
 
-// Bad: context baked into message — callers must parse to extract driverId
+// Bad: driverId and zoneId exist only inside message — callers must parse to extract them
 type DriverNotAvailableError = Readonly<{
   kind: "DriverNotAvailableError";
-  message: string; // "Driver drv-123 is not available"
+  message: string; // "Driver drv-123 is not available in zone zone-A"
 }>;
 ```
 


### PR DESCRIPTION
## Background

The kamae-review checklist items 3.1/3.2/3.3 verify syntactic conformance (whether a Result pattern is used) but lack checks for semantic correctness (whether the pattern is used correctly). Code that misapplies the pattern passes every check.

## Approach

Each of the three items gains an "Also flag:" paragraph targeting a specific semantic misuse: `fromSafePromise` wrapping fallible Promises (3.1), error DU variants with context data buried in `message` strings instead of typed fields (3.2), and procedural if/else branching inside `andThen` callbacks instead of flat pipelines of named functions (3.3). The kamae knowledge base (`error-handling.md`) gets matching sections so reviewers can cite authoritative guidance. The same additions are reflected in both en/ and ja/ documentation pages.

Note on 3.2: having a `message` field is fine for logging/display — the check targets cases where context data (IDs, codes) exists only in `message` and callers must parse it to branch or retry.

## Test Plan

- [ ] `bun run evals/runner/run.ts evals/kamae-review/eval.yaml --dry-run` passes (CI covers this)
- [ ] Real-model eval against the three new fixtures confirms the reviewer flags each violation

---
Generated with Claude Code

Closes #38
