### PR TITLE
docs(release): prepare v1.2.0 release notes

### DIFF
--- a/docs/superpowers/plans/2026-08-07-v1.2.0-release-notes.md
+++ b/docs/superpowers/plans/2026-08-07-v1.2.0-release-notes.md
@@ -134,7 +134,7 @@ https://github.com/iwasa-kosui/kamae-ts/compare/v1.1.0...v1.2.0
 Run:
 
 ```bash
-rg -n '^## (Highlights|Other Changes|Upgrade Notes|What.s Changed|Full Changelog)$' /tmp/kamae-ts-v1.2.0-release-notes.md
+rg -n "^## (Highlights|Other Changes|Upgrade Notes|What's Changed|Full Changelog)$" /tmp/kamae-ts-v1.2.0-release-notes.md
 rg -n '/pull/(41|42|43|44)' /tmp/kamae-ts-v1.2.0-release-notes.md
 rg -n 'There are no required end-user migrations\.' /tmp/kamae-ts-v1.2.0-release-notes.md
 rg -n 'compare/v1\.1\.0\.\.\.v1\.2\.0' /tmp/kamae-ts-v1.2.0-release-notes.md

--- a/docs/superpowers/plans/2026-08-07-v1.2.0-release-notes.md
+++ b/docs/superpowers/plans/2026-08-07-v1.2.0-release-notes.md
@@ -1,0 +1,200 @@
+# v1.2.0 Release Notes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create and verify an unpublished English GitHub Release draft for `v1.2.0` covering pull requests `#41` through `#44`.
+
+**Architecture:** Build the reviewed Markdown body in a temporary file, validate it against the fixed release range, then pass it to `gh release create`. Read the created release back from GitHub and verify its identity, target, draft state, and required content without publishing it.
+
+**Tech Stack:** Git, GitHub CLI (`gh`), Markdown, shell assertions with `jq` and `rg`
+
+## Global Constraints
+
+- Work in `/Users/kosui/ghq/github.com/iwasa-kosui/kamae-ts/.wt/docs/release-notes-v1.2.0` on branch `docs/release-notes-v1.2.0`.
+- Use release tag and title `v1.2.0`.
+- Target commit `423f98e7b91ef063d8e4b1b966740bdd851ab966`.
+- Cover exactly the changes from `v1.1.0` through the target commit, including pull requests `#41`, `#42`, `#43`, and `#44`.
+- Create a draft only. Do not publish the release or mark it as a prerelease.
+- Do not create a release commit or update `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, or `.github/workflows/release.yml`.
+- Do not add AI co-author acknowledgements; retain the existing GitHub-author attribution convention.
+- If a `v1.2.0` release already exists, stop before any write and report its URL and state.
+- If post-creation verification fails, leave the draft unpublished and report the mismatch. Do not delete or publish it automatically.
+
+---
+
+### Task 1: Validate the Release Range and Prepare the Body
+
+**Files:**
+- Create: `/tmp/kamae-ts-v1.2.0-release-notes.md`
+- Reference: `docs/superpowers/specs/2026-08-07-v1.2.0-release-notes-design.md`
+
+**Interfaces:**
+- Consumes: GitHub repository `iwasa-kosui/kamae-ts`, base tag `v1.1.0`, target commit `423f98e7b91ef063d8e4b1b966740bdd851ab966`
+- Produces: Validated Markdown at `/tmp/kamae-ts-v1.2.0-release-notes.md` for Task 2
+
+- [ ] **Step 1: Confirm the local execution context**
+
+Run:
+
+```bash
+git branch --show-current
+git rev-parse HEAD
+git status --short
+```
+
+Expected:
+
+```text
+docs/release-notes-v1.2.0
+38b8c6e... or a later plan-only commit whose parent history contains 423f98e...
+```
+
+`git status --short` must not show unrelated changes. The branch head may be ahead of the release target because the design and plan documents are committed on this branch; the GitHub Release itself must still target `423f98e7b91ef063d8e4b1b966740bdd851ab966`.
+
+- [ ] **Step 2: Verify that no v1.2.0 release already exists**
+
+Run:
+
+```bash
+gh release view v1.2.0 --repo iwasa-kosui/kamae-ts --json url,isDraft,isPrerelease,tagName
+```
+
+Expected: command exits non-zero with `release not found`. If it succeeds, stop without creating or editing anything and report the returned release.
+
+- [ ] **Step 3: Verify the fixed comparison range**
+
+Run:
+
+```bash
+gh api repos/iwasa-kosui/kamae-ts/compare/v1.1.0...423f98e7b91ef063d8e4b1b966740bdd851ab966 --jq '{status: .status, ahead_by: .ahead_by, commits: [.commits[].sha[0:7]]}'
+```
+
+Expected:
+
+```json
+{"ahead_by":4,"commits":["3aac9f0","9941efd","b92829e","423f98e"],"status":"ahead"}
+```
+
+If the status, count, or commit set differs, stop and report the discrepancy before creating the draft.
+
+- [ ] **Step 4: Create the reviewed release body**
+
+Use `apply_patch` to create `/tmp/kamae-ts-v1.2.0-release-notes.md` with this exact content:
+
+````markdown
+## Highlights
+
+### Infer types from validation schemas
+
+Kamae now treats runtime validation schemas as the single source of truth for boundary representations. Generated code derives TypeScript types with the detected library's inference API instead of duplicating the same shape in a separate type or interface.
+
+Kamae Review now reports duplicated schema-backed types as a Low-severity finding and escalates the severity when actual drift causes incorrect acceptance, rejection, or data exposure.
+
+### Preserve established import conventions
+
+Kamae now inspects nearby code and follows a project's consistent import and coding conventions. When a project has no established Zod convention, generated examples use the namespace import `import * as z from "zod"`.
+
+## Other Changes
+
+- Installation guidance now recommends installing `kamae` and `kamae-review` together.
+- Removed the unsupported Claude-driven evaluation runner and CI workflow.
+
+## Upgrade Notes
+
+There are no required end-user migrations.
+
+Existing duplicated schema and type definitions can be consolidated gradually:
+
+```typescript
+const CreateTaskInputSchema = z.object({
+  title: z.string(),
+});
+
+type CreateTaskInput = z.infer<typeof CreateTaskInputSchema>;
+```
+
+Use input/output-specific inference when schemas transform values or supply defaults.
+
+Maintainers who used `bun run eval` should note that the obsolete evaluation subsystem has been removed.
+
+## What's Changed
+
+- [docs(installation): include kamae-review in setup guidance](https://github.com/iwasa-kosui/kamae-ts/pull/41) by [@iwasa-kosui](https://github.com/iwasa-kosui)
+- [chore(evals): remove Claude-driven evaluation](https://github.com/iwasa-kosui/kamae-ts/pull/43) by [@iwasa-kosui](https://github.com/iwasa-kosui)
+- [fix(kamae): respect established import conventions](https://github.com/iwasa-kosui/kamae-ts/pull/42) by [@iwasa-kosui](https://github.com/iwasa-kosui)
+- [feat(kamae): infer types from validation schemas](https://github.com/iwasa-kosui/kamae-ts/pull/44) by [@iwasa-kosui](https://github.com/iwasa-kosui)
+
+## Full Changelog
+
+https://github.com/iwasa-kosui/kamae-ts/compare/v1.1.0...v1.2.0
+````
+
+- [ ] **Step 5: Validate the temporary body structurally**
+
+Run:
+
+```bash
+rg -n '^## (Highlights|Other Changes|Upgrade Notes|What.s Changed|Full Changelog)$' /tmp/kamae-ts-v1.2.0-release-notes.md
+rg -n '/pull/(41|42|43|44)' /tmp/kamae-ts-v1.2.0-release-notes.md
+rg -n 'There are no required end-user migrations\.' /tmp/kamae-ts-v1.2.0-release-notes.md
+rg -n 'compare/v1\.1\.0\.\.\.v1\.2\.0' /tmp/kamae-ts-v1.2.0-release-notes.md
+```
+
+Expected: five section headings, four distinct pull request links, the no-migration statement, and the exact comparison link are all present.
+
+### Task 2: Create and Verify the GitHub Release Draft
+
+**Files:**
+- Read: `/tmp/kamae-ts-v1.2.0-release-notes.md`
+- Create externally: GitHub Release draft `v1.2.0` in `iwasa-kosui/kamae-ts`
+
+**Interfaces:**
+- Consumes: The validated Markdown file from Task 1
+- Produces: An unpublished, non-prerelease GitHub Release draft targeting commit `423f98e7b91ef063d8e4b1b966740bdd851ab966`
+
+- [ ] **Step 1: Create the draft**
+
+Run:
+
+```bash
+gh release create v1.2.0 --repo iwasa-kosui/kamae-ts --title v1.2.0 --target 423f98e7b91ef063d8e4b1b966740bdd851ab966 --draft --notes-file /tmp/kamae-ts-v1.2.0-release-notes.md
+```
+
+Expected: command succeeds and prints the draft release URL. Do not add `--latest`, `--prerelease`, or any publication step.
+
+- [ ] **Step 2: Verify release metadata**
+
+Run:
+
+```bash
+gh release view v1.2.0 --repo iwasa-kosui/kamae-ts --json tagName,name,targetCommitish,isDraft,isPrerelease,url --jq '{tagName, name, targetCommitish, isDraft, isPrerelease, url}'
+```
+
+Expected:
+
+```json
+{"isDraft":true,"isPrerelease":false,"name":"v1.2.0","tagName":"v1.2.0","targetCommitish":"423f98e7b91ef063d8e4b1b966740bdd851ab966","url":"https://github.com/iwasa-kosui/kamae-ts/releases/tag/untagged-..."}
+```
+
+The URL suffix is generated by GitHub and may vary. All other values must match exactly.
+
+- [ ] **Step 3: Verify the stored body**
+
+Run:
+
+```bash
+gh release view v1.2.0 --repo iwasa-kosui/kamae-ts --json body --jq .body
+```
+
+Compare the output with `/tmp/kamae-ts-v1.2.0-release-notes.md`. Confirm all five headings, pull request links `#41` through `#44`, the no-migration statement, and the full changelog link are preserved.
+
+- [ ] **Step 4: Report the draft for maintainer review**
+
+Report the draft URL, tag, fixed target commit, draft/prerelease state, and the two publication follow-ups excluded from this task:
+
+```text
+- Decide whether `.claude-plugin/marketplace.json` should be updated from 1.0.0 before publication.
+- Confirm whether the evaluation fixtures retained after removing the runner are intentional.
+```
+
+Do not publish the release.

--- a/docs/superpowers/specs/2026-08-07-v1.2.0-release-notes-design.md
+++ b/docs/superpowers/specs/2026-08-07-v1.2.0-release-notes-design.md
@@ -1,0 +1,64 @@
+# v1.2.0 Release Notes Design
+
+## Goal
+
+Create an English GitHub Release draft for `v1.2.0` that explains the user-visible changes since `v1.1.0`. The draft should help skill users understand the new schema-inference behavior and reassure them that no mandatory migration is required.
+
+## Scope
+
+The release notes cover the four pull requests merged between `v1.1.0` and commit `423f98e7b91ef063d8e4b1b966740bdd851ab966` on `main`:
+
+- `#41`: recommend installing `kamae` and `kamae-review` together
+- `#42`: preserve established import and coding conventions
+- `#43`: remove the unsupported Claude-driven evaluation subsystem
+- `#44`: infer TypeScript types from validation schemas
+
+The work creates a draft release only. It does not publish the release, create a release commit, update version metadata, modify the release workflow, or resolve the stale version in `.claude-plugin/marketplace.json`.
+
+## Version and Release Target
+
+Use `v1.2.0`. The schema-inference change is a backward-compatible feature, and no commit declares a breaking change, so a SemVer minor release is appropriate.
+
+Target commit `423f98e7b91ef063d8e4b1b966740bdd851ab966` when creating the draft so later changes to `main` cannot silently enter this release. The release must remain unpublished for maintainer review.
+
+## Content Structure
+
+The body follows the repository's existing GitHub Release style while adding a curated introduction:
+
+1. `Highlights`
+   - Explain schema-backed type inference as the main feature.
+   - Explain that Kamae now preserves established project import conventions.
+2. `Other Changes`
+   - Mention the improved installation guidance.
+   - Mention removal of the unsupported evaluation subsystem.
+3. `Upgrade Notes`
+   - State that end users have no required migration.
+   - Show one concise Zod inference example.
+   - Note that input/output-specific inference is appropriate for transformations and defaults.
+   - Warn maintainers that the former `bun run eval` workflow is no longer available.
+4. `What's Changed`
+   - List pull requests `#41` through `#44` with links and author attribution.
+5. `Full Changelog`
+   - Link to the comparison from `v1.1.0` to `v1.2.0`.
+
+The prose should be concise, user-facing, and free of internal implementation detail unless it affects upgrading or contributing.
+
+## Exclusions and Known Release Follow-ups
+
+Do not describe `.claude-plugin/marketplace.json` version drift or partially retained evaluation fixtures as user-facing release changes. These are release-readiness follow-ups for the maintainer and should be resolved separately before publication if necessary.
+
+Do not add AI co-author acknowledgements to the release body. Existing release notes attribute merged pull requests to their GitHub authors, so the draft should preserve that convention.
+
+## Verification
+
+After creating the draft, verify through GitHub that:
+
+- the tag name and release title are `v1.2.0`;
+- the target is commit `423f98e7b91ef063d8e4b1b966740bdd851ab966`;
+- the release is a draft and is not published or marked as a prerelease;
+- all five body sections are present;
+- pull requests `#41`, `#42`, `#43`, and `#44` are linked;
+- the comparison link uses `v1.1.0...v1.2.0`;
+- the body does not claim that users must migrate.
+
+No repository test suite covers GitHub Release prose. Verification is therefore structural and factual rather than executable.


### PR DESCRIPTION
## Background

The upcoming `v1.2.0` release needs curated notes that explain the user-visible changes since `v1.1.0` while preserving the repository's existing GitHub Release conventions.

## Approach

Define a concise, reproducible release-note workflow around a fixed target commit and a draft-only publication boundary. The resulting draft emphasizes schema-derived types and project-local import conventions, while keeping maintainer-only follow-ups outside the user-facing copy.

## Discussion

Before publishing the release, decide whether to synchronize `.claude-plugin/marketplace.json` with the new version and confirm whether the evaluation fixtures retained after removing the runner are intentional.

---
Generated with Codex
